### PR TITLE
fix: remove import code

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,8 +8,6 @@ import { WagmiConfig, configureChains, createConfig } from 'wagmi';
 import { hardhat } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
 
-// import "../src/theme";
-
 const { publicClient, webSocketPublicClient } = configureChains([hardhat], [publicProvider()]);
 
 const config = createConfig({


### PR DESCRIPTION
During the build of Storybook, a parsing error occurred due to an unused import statement.