### PR TITLE
fix: errors on `bigint`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
-    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.109",
+    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.110",
     "@floating-ui/dom": "^1.4.2",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
-    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.107",
+    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.109",
     "@floating-ui/dom": "^1.4.2",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",

--- a/src/hooks/useError.ts
+++ b/src/hooks/useError.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Logger } from '~/utils/log';
+import { isValid } from '~/utils/valid';
 
 const defaultLogger = Logger('Error');
 
@@ -13,10 +14,10 @@ export function useError({ error, logger }: Props) {
   useEffect(() => {
     if (error) {
       if (error instanceof Array) {
-        error.forEach((err) => (logger ?? defaultLogger).error(err));
+        error.filter((err) => isValid(err)).forEach((err) => (logger ?? defaultLogger).error(err));
       } else {
         (logger ?? defaultLogger).error(error);
       }
     }
-  }, [error]);
+  }, [error, logger]);
 }

--- a/src/hooks/useMargins.ts
+++ b/src/hooks/useMargins.ts
@@ -1,7 +1,5 @@
 import { isNil } from 'ramda';
 import { useMemo } from 'react';
-import { formatUnits, parseUnits } from 'viem';
-import { PERCENT_DECIMALS } from '~/configs/decimals';
 import { useAppSelector } from '~/store';
 import { usePositions } from './usePositions';
 import { useUsumAccount } from './useUsumAccount';
@@ -20,12 +18,7 @@ export function useMargins() {
     const balance = balances[token.address];
     const [totalCollateral, totalCollateralAdded] = positions.reduce(
       (record, position) => {
-        const added = parseUnits(
-          formatUnits(position.collateral * position.pnl, token.decimals * 2 + PERCENT_DECIMALS),
-          token.decimals
-        );
-
-        return [record[0] + position.collateral, record[1] + added];
+        return [record[0] + position.collateral, record[1] + position.collateral + position.pnl];
       },
       [0n, 0n]
     );

--- a/src/hooks/useMargins.ts
+++ b/src/hooks/useMargins.ts
@@ -1,9 +1,8 @@
 import { isNil } from 'ramda';
 import { useMemo } from 'react';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { PERCENT_DECIMALS } from '~/configs/decimals';
 import { useAppSelector } from '~/store';
-import { toBigInt } from '~/utils/number';
 import { usePositions } from './usePositions';
 import { useUsumAccount } from './useUsumAccount';
 
@@ -21,8 +20,9 @@ export function useMargins() {
     const balance = balances[token.address];
     const [totalCollateral, totalCollateralAdded] = positions.reduce(
       (record, position) => {
-        const added = toBigInt(
-          formatUnits(position.collateral * position.pnl, token.decimals + PERCENT_DECIMALS)
+        const added = parseUnits(
+          formatUnits(position.collateral * position.pnl, token.decimals * 2 + PERCENT_DECIMALS),
+          token.decimals
         );
 
         return [record[0] + position.collateral, record[1] + added];

--- a/src/hooks/useOwnedLiquidityPool.ts
+++ b/src/hooks/useOwnedLiquidityPool.ts
@@ -1,12 +1,11 @@
 import { utils as ChromaticUtils } from '@chromatic-protocol/sdk-viem';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { formatUnits, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useChromaticClient } from '~/hooks/useChromaticClient';
 import { OwnedBin } from '~/typings/pools';
 import { filterIfFulfilled } from '~/utils/array';
-import { divPreserved } from '~/utils/number';
+import { divPreserved, mulPreserved } from '~/utils/number';
 import { useAppSelector } from '../store';
 import { checkAllProps } from '../utils';
 import { Logger } from '../utils/log';
@@ -55,10 +54,7 @@ export const useOwnedLiquidityPool = () => {
           clbTokenValue: bin.clbValue,
           clbTotalSupply: bin.clbTotalSupply,
           binValue: bin.binValue,
-          clbBalanceOfSettlement: parseUnits(
-            formatUnits(bin.clbBalance * bin.clbValue, decimals * 2),
-            decimals
-          ),
+          clbBalanceOfSettlement: mulPreserved(bin.clbBalance, bin.clbValue, decimals),
           baseFeeRate: Number(bin.tradingFeeRate),
           tokenId: tokenId,
         } satisfies OwnedBin;

--- a/src/hooks/useOwnedLiquidityPool.ts
+++ b/src/hooks/useOwnedLiquidityPool.ts
@@ -1,12 +1,12 @@
 import { utils as ChromaticUtils } from '@chromatic-protocol/sdk-viem';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useChromaticClient } from '~/hooks/useChromaticClient';
 import { OwnedBin } from '~/typings/pools';
 import { filterIfFulfilled } from '~/utils/array';
-import { divPreserved, toBigInt } from '~/utils/number';
+import { divPreserved } from '~/utils/number';
 import { useAppSelector } from '../store';
 import { checkAllProps } from '../utils';
 import { Logger } from '../utils/log';
@@ -55,7 +55,10 @@ export const useOwnedLiquidityPool = () => {
           clbTokenValue: bin.clbValue,
           clbTotalSupply: bin.clbTotalSupply,
           binValue: bin.binValue,
-          clbBalanceOfSettlement: toBigInt(formatUnits(bin.clbBalance * bin.clbValue, decimals)),
+          clbBalanceOfSettlement: parseUnits(
+            formatUnits(bin.clbBalance * bin.clbValue, decimals * 2),
+            decimals
+          ),
           baseFeeRate: Number(bin.tradingFeeRate),
           tokenId: tokenId,
         } satisfies OwnedBin;

--- a/src/hooks/useOwnedLiquidityPools.ts
+++ b/src/hooks/useOwnedLiquidityPools.ts
@@ -2,14 +2,13 @@ import { utils as ChromaticUtils } from '@chromatic-protocol/sdk-viem';
 import { isNil } from 'ramda';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { formatUnits, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
 import { OwnedBin } from '~/typings/pools';
 import { filterIfFulfilled } from '~/utils/array';
 import { checkAllProps } from '../utils';
 import { Logger } from '../utils/log';
-import { divPreserved } from '../utils/number';
+import { divPreserved, mulPreserved } from '../utils/number';
 import { PromiseOnlySuccess } from '../utils/promise';
 import { useChromaticClient } from './useChromaticClient';
 import { useError } from './useError';
@@ -71,10 +70,7 @@ export const useOwnedLiquidityPools = () => {
               clbTokenValue: bin.clbValue,
               clbTotalSupply: bin.clbTotalSupply,
               binValue: bin.binValue,
-              clbBalanceOfSettlement: parseUnits(
-                formatUnits(bin.clbBalance * bin.clbValue, decimals * 2),
-                decimals
-              ),
+              clbBalanceOfSettlement: mulPreserved(bin.clbBalance, bin.clbValue, decimals),
               baseFeeRate: bin.tradingFeeRate,
               tokenId: tokenId,
             } satisfies OwnedBin;

--- a/src/hooks/useOwnedLiquidityPools.ts
+++ b/src/hooks/useOwnedLiquidityPools.ts
@@ -2,14 +2,14 @@ import { utils as ChromaticUtils } from '@chromatic-protocol/sdk-viem';
 import { isNil } from 'ramda';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
 import { OwnedBin } from '~/typings/pools';
 import { filterIfFulfilled } from '~/utils/array';
 import { checkAllProps } from '../utils';
 import { Logger } from '../utils/log';
-import { divPreserved, toBigInt } from '../utils/number';
+import { divPreserved } from '../utils/number';
 import { PromiseOnlySuccess } from '../utils/promise';
 import { useChromaticClient } from './useChromaticClient';
 import { useError } from './useError';
@@ -71,8 +71,9 @@ export const useOwnedLiquidityPools = () => {
               clbTokenValue: bin.clbValue,
               clbTotalSupply: bin.clbTotalSupply,
               binValue: bin.binValue,
-              clbBalanceOfSettlement: toBigInt(
-                formatUnits(bin.clbBalance * bin.clbValue, decimals)
+              clbBalanceOfSettlement: parseUnits(
+                formatUnits(bin.clbBalance * bin.clbValue, decimals * 2),
+                decimals
               ),
               baseFeeRate: bin.tradingFeeRate,
               tokenId: tokenId,

--- a/src/hooks/usePoolReceipt.ts
+++ b/src/hooks/usePoolReceipt.ts
@@ -56,7 +56,8 @@ const receiptDetail = (
 const usePoolReceipt = () => {
   const market = useAppSelector((state) => state.market.selectedMarket);
   const { client } = useChromaticClient();
-  const router = useMemo(() => client?.router(), [client]);
+  const router = useMemo(() => client?.router(), [client?.walletClient]);
+  const lensApi = useMemo(() => client?.lens(), [client, client?.walletClient]);
   const { oracleVersions } = useOracleVersion();
   const { address } = useAccount();
   const currentOracleVersion = market && oracleVersions?.[market.address]?.version;
@@ -72,7 +73,7 @@ const usePoolReceipt = () => {
 
   const fetchKey = {
     name: 'getPoolReceipt',
-    lensApi: useMemo(() => client?.lens(), [client]),
+    lensApi,
     address: address,
     currentOracleVersion: currentOracleVersion,
     marketAddress: marketAddress,
@@ -94,7 +95,8 @@ const usePoolReceipt = () => {
         oracleVersion: receipt.oracleVersion,
       }));
       const ownedBins = await lensApi.claimableLiquidities(marketAddress, ownedBinsParam);
-
+      console.log('Receipts', receipts);
+      console.log('Owned bins', ownedBins);
       return receipts
         .map((receipt) => {
           const bin = ownedBins.find((bin) => bin.tradingFeeRate === receipt.tradingFeeRate);

--- a/src/hooks/usePoolReceipt.ts
+++ b/src/hooks/usePoolReceipt.ts
@@ -56,8 +56,8 @@ const receiptDetail = (
 const usePoolReceipt = () => {
   const market = useAppSelector((state) => state.market.selectedMarket);
   const { client } = useChromaticClient();
-  const router = useMemo(() => client?.router(), [client?.walletClient]);
-  const lensApi = useMemo(() => client?.lens(), [client, client?.walletClient]);
+  const router = useMemo(() => client?.router(), [client]);
+  const lensApi = useMemo(() => client?.lens(), [client]);
   const { oracleVersions } = useOracleVersion();
   const { address } = useAccount();
   const currentOracleVersion = market && oracleVersions?.[market.address]?.version;
@@ -95,8 +95,6 @@ const usePoolReceipt = () => {
         oracleVersion: receipt.oracleVersion,
       }));
       const ownedBins = await lensApi.claimableLiquidities(marketAddress, ownedBinsParam);
-      console.log('Receipts', receipts);
-      console.log('Owned bins', ownedBins);
       return receipts
         .map((receipt) => {
           const bin = ownedBins.find((bin) => bin.tradingFeeRate === receipt.tradingFeeRate);

--- a/src/hooks/usePoolRemoveInput.ts
+++ b/src/hooks/usePoolRemoveInput.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { formatUnits, parseUnits } from 'viem';
 import { MULTI_ALL, MULTI_TYPE } from '~/configs/pool';
 import { useAppSelector } from '~/store';
-import { formatDecimals, toBigInt } from '~/utils/number';
+import { formatDecimals, fromExponentials } from '~/utils/number';
 
 export const usePoolRemoveInput = () => {
   const [amount, setAmount] = useState('');
@@ -26,7 +26,7 @@ export const usePoolRemoveInput = () => {
       if (isNaN(Number(nextAmount))) {
         return;
       }
-      setAmount(nextAmount);
+      setAmount(fromExponentials(nextAmount));
     } else {
       setAmount(String(nextAmount));
     }

--- a/src/hooks/usePoolRemoveInput.ts
+++ b/src/hooks/usePoolRemoveInput.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { MULTI_ALL, MULTI_TYPE } from '~/configs/pool';
 import { useAppSelector } from '~/store';
 import { formatDecimals, toBigInt } from '~/utils/number';
@@ -53,7 +53,10 @@ export const useMultiPoolRemoveInput = () => {
     }
     const removableBalance = bins
       .map((bin) =>
-        toBigInt(formatUnits(bin.clbTokenBalance * bin.removableRate, bin.clbTokenDecimals))
+        parseUnits(
+          formatUnits(bin.clbTokenBalance * bin.removableRate, bin.clbTokenDecimals * 2),
+          bin.clbTokenDecimals
+        )
       )
       .reduce((balance, removable) => balance + removable, 0n);
     return Number(formatDecimals(removableBalance, token?.decimals, token?.decimals));

--- a/src/hooks/usePoolRemoveInput.ts
+++ b/src/hooks/usePoolRemoveInput.ts
@@ -2,7 +2,9 @@ import { useMemo, useState } from 'react';
 import { formatUnits } from 'viem';
 import { MULTI_ALL, MULTI_TYPE } from '~/configs/pool';
 import { useAppSelector } from '~/store';
-import { fromExponentials, mulPreserved } from '~/utils/number';
+import { mulPreserved } from '~/utils/number';
+
+const formatter = Intl.NumberFormat('en', { useGrouping: false });
 
 export const usePoolRemoveInput = () => {
   const [amount, setAmount] = useState('');
@@ -23,11 +25,12 @@ export const usePoolRemoveInput = () => {
       if (isNaN(Number(nextAmount))) {
         return;
       }
-      setAmount(fromExponentials(nextAmount));
+      setAmount(formatter.format(Number(nextAmount)));
+      return;
     } else {
-      setAmount(String(nextAmount));
+      setAmount(formatter.format(nextAmount));
+      return;
     }
-    setAmount(String(nextAmount));
   };
 
   return { amount, maxAmount, onAmountChange };

--- a/src/hooks/useRemoveLiquidities.ts
+++ b/src/hooks/useRemoveLiquidities.ts
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
-import { formatUnits, parseUnits } from 'viem';
 import { useAccount, useWalletClient } from 'wagmi';
 import { MULTI_ALL, MULTI_TYPE } from '~/configs/pool';
 import { useAppDispatch, useAppSelector } from '~/store';
 import { poolsAction } from '~/store/reducer/pools';
 import { PoolEvent } from '~/typings/events';
 import { OwnedBin } from '~/typings/pools';
+import { mulPreserved } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { useChromaticClient } from './useChromaticClient';
 import { useLiquidityPool } from './useLiquidityPool';
@@ -68,10 +68,7 @@ function useRemoveLiquidities(props: Props) {
     try {
       const amounts = bins.map((bin) => {
         const { clbTokenBalance, clbTokenDecimals, removableRate } = bin;
-        const removable = parseUnits(
-          formatUnits(clbTokenBalance * removableRate, clbTokenDecimals * 2),
-          clbTokenDecimals
-        );
+        const removable = mulPreserved(clbTokenBalance, removableRate, clbTokenDecimals);
 
         return type === MULTI_ALL ? clbTokenBalance : removable;
       });

--- a/src/hooks/useRemoveLiquidities.ts
+++ b/src/hooks/useRemoveLiquidities.ts
@@ -1,13 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { useAccount, useWalletClient } from 'wagmi';
 import { MULTI_ALL, MULTI_TYPE } from '~/configs/pool';
 import { useAppDispatch, useAppSelector } from '~/store';
 import { poolsAction } from '~/store/reducer/pools';
 import { PoolEvent } from '~/typings/events';
 import { OwnedBin } from '~/typings/pools';
-import { toBigInt } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { useChromaticClient } from './useChromaticClient';
 import { useLiquidityPool } from './useLiquidityPool';
@@ -69,7 +68,10 @@ function useRemoveLiquidities(props: Props) {
     try {
       const amounts = bins.map((bin) => {
         const { clbTokenBalance, clbTokenDecimals, removableRate } = bin;
-        const removable = toBigInt(formatUnits(clbTokenBalance * removableRate, clbTokenDecimals));
+        const removable = parseUnits(
+          formatUnits(clbTokenBalance * removableRate, clbTokenDecimals * 2),
+          clbTokenDecimals
+        );
 
         return type === MULTI_ALL ? clbTokenBalance : removable;
       });

--- a/src/hooks/useRemoveLiquidity.ts
+++ b/src/hooks/useRemoveLiquidity.ts
@@ -70,7 +70,7 @@ function useRemoveLiquidity(props: Props) {
     try {
       await routerApi.removeLiquidity(pool.marketAddress, {
         feeRate,
-        receipient: address,
+        recipient: address,
         clbTokenAmount: expandedAmount,
       });
       dispatch(poolsAction.onBinsReset());

--- a/src/hooks/useRemoveLiquidity.ts
+++ b/src/hooks/useRemoveLiquidity.ts
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from '~/store';
 import { poolsAction } from '~/store/reducer/pools';
 import { PoolEvent } from '~/typings/events';
 import { Logger } from '~/utils/log';
+import { fromExponentials } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { useChromaticClient } from './useChromaticClient';
 import { useLiquidityPools } from './useLiquidityPool';
@@ -64,7 +65,7 @@ function useRemoveLiquidity(props: Props) {
       toast('Create Chromatic account.');
       return;
     }
-    const expandedAmount = parseUnits(amount.toString(), token!.decimals);
+    const expandedAmount = parseUnits(fromExponentials(amount), token!.decimals);
 
     try {
       await routerApi.removeLiquidity(pool.marketAddress, {

--- a/src/hooks/useRemoveLiquidity.ts
+++ b/src/hooks/useRemoveLiquidity.ts
@@ -6,7 +6,6 @@ import { useAppDispatch, useAppSelector } from '~/store';
 import { poolsAction } from '~/store/reducer/pools';
 import { PoolEvent } from '~/typings/events';
 import { Logger } from '~/utils/log';
-import { fromExponentials } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { useChromaticClient } from './useChromaticClient';
 import { useLiquidityPools } from './useLiquidityPool';
@@ -18,6 +17,7 @@ interface Props {
 }
 
 const logger = Logger('useRemoveLiquidity');
+const formatter = Intl.NumberFormat('en', { useGrouping: false });
 
 function useRemoveLiquidity(props: Props) {
   const { amount, feeRate } = props;
@@ -65,7 +65,7 @@ function useRemoveLiquidity(props: Props) {
       toast('Create Chromatic account.');
       return;
     }
-    const expandedAmount = parseUnits(fromExponentials(amount), token!.decimals);
+    const expandedAmount = parseUnits(formatter.format(Number(amount)), token!.decimals);
 
     try {
       await routerApi.removeLiquidity(pool.marketAddress, {

--- a/src/hooks/useTradeInput.ts
+++ b/src/hooks/useTradeInput.ts
@@ -1,6 +1,6 @@
 import { isNil } from 'ramda';
 import { useMemo, useReducer } from 'react';
-import { formatUnits, parseUnits } from 'viem';
+import { formatUnits } from 'viem';
 import { FEE_RATE_DECIMAL, PERCENT_DECIMALS } from '~/configs/decimals';
 import { TradeInput, TradeInputAction } from '~/typings/trade';
 import {
@@ -8,6 +8,7 @@ import {
   decimalLength,
   divPreserved,
   formatDecimals,
+  mulPreserved,
   numberBuffer,
   toBigintWithDecimals,
 } from '~/utils/number';
@@ -225,23 +226,13 @@ export const useTradeInput = () => {
       if (makerMargin <= 0n) {
         break;
       }
-      const { baseFeeRate, freeLiquidity, clbTokenDecimals } = token;
+      const { baseFeeRate, freeLiquidity } = token;
       const feeRate = abs(baseFeeRate);
       if (makerMargin >= freeLiquidity) {
-        tradeFee =
-          tradeFee +
-          parseUnits(
-            formatUnits(freeLiquidity * feeRate, clbTokenDecimals + FEE_RATE_DECIMAL),
-            clbTokenDecimals
-          );
+        tradeFee = tradeFee + mulPreserved(freeLiquidity, feeRate, FEE_RATE_DECIMAL);
         makerMargin = makerMargin - freeLiquidity;
       } else {
-        tradeFee =
-          tradeFee +
-          parseUnits(
-            formatUnits(makerMargin * feeRate, clbTokenDecimals + FEE_RATE_DECIMAL),
-            clbTokenDecimals
-          );
+        tradeFee = tradeFee + mulPreserved(makerMargin, feeRate, FEE_RATE_DECIMAL);
         makerMargin = 0n;
       }
     }

--- a/src/stories/molecule/LiquidityItem/index.tsx
+++ b/src/stories/molecule/LiquidityItem/index.tsx
@@ -5,7 +5,7 @@ import { Progress } from '~/stories/atom/Progress';
 import { Thumbnail } from '~/stories/atom/Thumbnail';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { divPreserved } from '~/utils/number';
+import { divPreserved, fromExponentials } from '~/utils/number';
 
 interface LiquidityItemProps {
   token?: Token;
@@ -62,11 +62,11 @@ export const LiquidityItem = (props: LiquidityItemProps) => {
         />
         <div className="flex justify-between gap-2 mt-1">
           <p className="text-left">
-            {Number(formatUnits(removable, token.decimals))} {token.name}
+            {fromExponentials(formatUnits(removable, token.decimals))} {token.name}
             <span className="text-black/30 ml-[2px]">({removableRate}%)</span>
           </p>
           <p className="text-right">
-            {Number(formatUnits(utilized, token.decimals))} {token.name}
+            {fromExponentials(formatUnits(utilized, token.decimals))} {token.name}
             <span className="text-black/30 ml-[2px]">({utilizedRate}%)</span>
           </p>
         </div>

--- a/src/stories/molecule/LiquidityItem/index.tsx
+++ b/src/stories/molecule/LiquidityItem/index.tsx
@@ -21,14 +21,20 @@ export const LiquidityItem = (props: LiquidityItemProps) => {
   const removable =
     freeLiquidity > clbBalanceOfSettlement ? clbBalanceOfSettlement : bin.freeLiquidity;
   const utilized = clbBalanceOfSettlement - removable;
-  const utilizedRate = formatUnits(
-    divPreserved(utilized, clbBalanceOfSettlement, token.decimals),
-    token.decimals - 2
-  );
-  const removableRate = formatUnits(
-    divPreserved(removable, clbBalanceOfSettlement, token.decimals),
-    token.decimals - 2
-  );
+  const utilizedRate =
+    clbBalanceOfSettlement !== 0n
+      ? formatUnits(
+          divPreserved(utilized, clbBalanceOfSettlement, token.decimals),
+          token.decimals - 2
+        )
+      : '0';
+  const removableRate =
+    clbBalanceOfSettlement !== 0n
+      ? formatUnits(
+          divPreserved(removable, clbBalanceOfSettlement, token.decimals),
+          token.decimals - 2
+        )
+      : '0';
   // 숫자에 천단위 쉼표 추가
   // 소수점 2자리 표기
   return (

--- a/src/stories/molecule/LiquidityItem/index.tsx
+++ b/src/stories/molecule/LiquidityItem/index.tsx
@@ -5,13 +5,18 @@ import { Progress } from '~/stories/atom/Progress';
 import { Thumbnail } from '~/stories/atom/Thumbnail';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { divPreserved, fromExponentials } from '~/utils/number';
+import { divPreserved, formatDecimals } from '~/utils/number';
 
 interface LiquidityItemProps {
   token?: Token;
   name?: string;
   bin?: OwnedBin;
 }
+const formatter = Intl.NumberFormat('en', {
+  useGrouping: true,
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+});
 
 export const LiquidityItem = (props: LiquidityItemProps) => {
   const { token, name, bin } = props;
@@ -23,16 +28,18 @@ export const LiquidityItem = (props: LiquidityItemProps) => {
   const utilized = clbBalanceOfSettlement - removable;
   const utilizedRate =
     clbBalanceOfSettlement !== 0n
-      ? formatUnits(
+      ? formatDecimals(
           divPreserved(utilized, clbBalanceOfSettlement, token.decimals),
-          token.decimals - 2
+          token.decimals - 2,
+          2
         )
       : '0';
   const removableRate =
     clbBalanceOfSettlement !== 0n
-      ? formatUnits(
+      ? formatDecimals(
           divPreserved(removable, clbBalanceOfSettlement, token.decimals),
-          token.decimals - 2
+          token.decimals - 2,
+          2
         )
       : '0';
   // 숫자에 천단위 쉼표 추가
@@ -47,7 +54,7 @@ export const LiquidityItem = (props: LiquidityItemProps) => {
         </div>
         <div className="ml-auto text-right">
           <p className="text-black/30">Qty</p>
-          <p className="mt-2 text-lg">{formatUnits(bin.clbTokenBalance, token.decimals)}</p>
+          <p className="mt-2 text-lg">{formatDecimals(bin.clbTokenBalance, token.decimals, 2)}</p>
         </div>
       </div>
       <div className="text-sm">
@@ -62,11 +69,11 @@ export const LiquidityItem = (props: LiquidityItemProps) => {
         />
         <div className="flex justify-between gap-2 mt-1">
           <p className="text-left">
-            {fromExponentials(formatUnits(removable, token.decimals))} {token.name}
+            {formatter.format(Number(formatUnits(removable, token.decimals)))} {token.name}
             <span className="text-black/30 ml-[2px]">({removableRate}%)</span>
           </p>
           <p className="text-right">
-            {fromExponentials(formatUnits(utilized, token.decimals))} {token.name}
+            {formatter.format(Number(formatUnits(utilized, token.decimals)))} {token.name}
             <span className="text-black/30 ml-[2px]">({utilizedRate}%)</span>
           </p>
         </div>

--- a/src/stories/molecule/PoolProgress/index.tsx
+++ b/src/stories/molecule/PoolProgress/index.tsx
@@ -1,19 +1,18 @@
 import { Disclosure, Tab } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import CheckIcon from '~/assets/icons/CheckIcon';
-import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Avatar } from '~/stories/atom/Avatar';
 import { Button } from '~/stories/atom/Button';
 import { Guide } from '~/stories/atom/Guide';
 import { Loading } from '~/stories/atom/Loading';
 import { Progress } from '~/stories/atom/Progress';
+import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Tag } from '~/stories/atom/Tag';
 import { Thumbnail } from '~/stories/atom/Thumbnail';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import '../../atom/Tabs/style.css';
 // import { LPReceipt } from "~/typings/receipt";
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
 import { useLastOracle } from '~/hooks/useLastOracle';
 import { usePrevious } from '~/hooks/usePrevious';
 import { POOL_EVENT } from '~/typings/events';
@@ -72,8 +71,6 @@ export const PoolProgress = ({
       if (isValid(openButtonRef.current) && !isOpen) {
         setHasGuide(true);
         openButtonRef.current.click();
-      } else {
-        toast.error('Check receipts manually please.');
       }
     }
     window.addEventListener(POOL_EVENT, onPool);

--- a/src/stories/template/RemoveLiquidityModal/index.tsx
+++ b/src/stories/template/RemoveLiquidityModal/index.tsx
@@ -10,7 +10,7 @@ import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { LiquidityItem } from '~/stories/molecule/LiquidityItem';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { formatDecimals } from '~/utils/number';
+import { formatDecimals, fromExponentials } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Button } from '../../atom/Button';
 import '../Modal/style.css';
@@ -114,7 +114,8 @@ export const RemoveLiquidityModal = (props: RemoveLiquidityModalProps) => {
                   (
                   {selectedBin &&
                     formatUnits(
-                      parseUnits(amount, selectedBin.clbTokenDecimals) * selectedBin?.clbTokenValue,
+                      parseUnits(fromExponentials(amount), selectedBin.clbTokenDecimals) *
+                        selectedBin?.clbTokenValue,
                       selectedBin.clbTokenDecimals * 2
                     )}{' '}
                   {token?.name})

--- a/src/stories/template/RemoveLiquidityModal/index.tsx
+++ b/src/stories/template/RemoveLiquidityModal/index.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@headlessui/react';
-import { formatUnits, parseUnits } from 'viem';
+import { parseUnits } from 'viem';
 import { useRemoveLiquidity } from '~/hooks/useRemoveLiquidity';
 import { useAppDispatch } from '~/store';
 import { poolsAction } from '~/store/reducer/pools';
@@ -10,7 +10,7 @@ import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { LiquidityItem } from '~/stories/molecule/LiquidityItem';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { formatDecimals, fromExponentials } from '~/utils/number';
+import { formatDecimals } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Button } from '../../atom/Button';
 import '../Modal/style.css';
@@ -22,6 +22,8 @@ export interface RemoveLiquidityModalProps {
   maxAmount?: number;
   onAmountChange?: (nextAmount: string) => unknown;
 }
+
+const formatter = Intl.NumberFormat('en', { useGrouping: false });
 
 export const RemoveLiquidityModal = (props: RemoveLiquidityModalProps) => {
   const { selectedBin, token, amount = '', maxAmount, onAmountChange } = props;
@@ -95,7 +97,7 @@ export const RemoveLiquidityModal = (props: RemoveLiquidityModalProps) => {
                   <p>
                     {formatDecimals(selectedBin.freeLiquidity, token.decimals, 2)} {token.name}
                     <span className="ml-1 text-black/30">
-                      ({formatUnits(selectedBin.removableRate, token.decimals)}%)
+                      ({formatDecimals(selectedBin.removableRate, token.decimals, 2)}%)
                     </span>
                   </p>
                 )}
@@ -113,10 +115,11 @@ export const RemoveLiquidityModal = (props: RemoveLiquidityModalProps) => {
                    */}
                   (
                   {selectedBin &&
-                    formatUnits(
-                      parseUnits(fromExponentials(amount), selectedBin.clbTokenDecimals) *
+                    formatDecimals(
+                      parseUnits(formatter.format(Number(amount)), selectedBin.clbTokenDecimals) *
                         selectedBin?.clbTokenValue,
-                      selectedBin.clbTokenDecimals * 2
+                      selectedBin.clbTokenDecimals * 2,
+                      2
                     )}{' '}
                   {token?.name})
                 </p>

--- a/src/stories/template/RemoveMultiLiquidityModal/index.tsx
+++ b/src/stories/template/RemoveMultiLiquidityModal/index.tsx
@@ -12,7 +12,7 @@ import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { LiquidityItem } from '~/stories/molecule/LiquidityItem';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { formatDecimals, toBigInt } from '~/utils/number';
+import { formatDecimals, fromExponentials } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Logger } from '../../../utils/log';
 import { Button } from '../../atom/Button';
@@ -74,7 +74,7 @@ export const RemoveMultiLiquidityModal = (props: RemoveMultiLiquidityModalProps)
       .map((bin) => bin.clbTokenBalance)
       .reduce((b, curr) => b + curr, 0n);
     const totalBalanceOfSettlement = selectedBins.reduce((sum, current) => {
-      return sum + toBigInt(formatUnits(current.clbBalanceOfSettlement, token?.decimals ?? 0));
+      return sum + current.clbBalanceOfSettlement;
     }, 0n);
     const totalLiquidity = selectedBins.reduce((acc, current) => {
       acc += current.liquidity;
@@ -216,7 +216,7 @@ export const RemoveMultiLiquidityModal = (props: RemoveMultiLiquidityModalProps)
                    * 사용자가 입력한 제거 하려는 LP 토큰의 개수에 대해서 USDC 값으로 변환하는 로직입니다.
                    */}
                   {/* {formatDecimals(convertedAmount, token?.decimals, 2)} {token?.name} */}
-                  {convertedAmount} {token?.name}
+                  {fromExponentials(convertedAmount)} {token?.name}
                 </p>
               </div>
               <div className="flex items-center justify-between gap-6 mt-3">

--- a/src/stories/template/RemoveMultiLiquidityModal/index.tsx
+++ b/src/stories/template/RemoveMultiLiquidityModal/index.tsx
@@ -12,13 +12,18 @@ import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { LiquidityItem } from '~/stories/molecule/LiquidityItem';
 import { Token } from '~/typings/market';
 import { OwnedBin } from '~/typings/pools';
-import { formatDecimals, fromExponentials } from '~/utils/number';
+import { formatDecimals } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Logger } from '../../../utils/log';
 import { Button } from '../../atom/Button';
 import '../Modal/style.css';
 
 const logger = Logger('RemoveMultiLiquidityModal');
+const formatter = Intl.NumberFormat('en', {
+  useGrouping: true,
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+});
 export interface RemoveMultiLiquidityModalProps {
   selectedBins?: OwnedBin[];
   amount?: number;
@@ -216,7 +221,7 @@ export const RemoveMultiLiquidityModal = (props: RemoveMultiLiquidityModalProps)
                    * 사용자가 입력한 제거 하려는 LP 토큰의 개수에 대해서 USDC 값으로 변환하는 로직입니다.
                    */}
                   {/* {formatDecimals(convertedAmount, token?.decimals, 2)} {token?.name} */}
-                  {fromExponentials(convertedAmount)} {token?.name}
+                  {formatter.format(convertedAmount)} {token?.name}
                 </p>
               </div>
               <div className="flex items-center justify-between gap-6 mt-3">

--- a/src/stories/template/TradeBar/index.tsx
+++ b/src/stories/template/TradeBar/index.tsx
@@ -21,7 +21,7 @@ import { TRADE_EVENT } from '~/typings/events';
 import { Market, Token } from '~/typings/market';
 import { OracleVersion } from '~/typings/oracleVersion';
 import { CLOSED, CLOSING, OPENED, OPENING, Position } from '~/typings/position';
-import { abs, divPreserved, formatDecimals, mulPreserved, withComma } from '~/utils/number';
+import { abs, divPreserved, formatDecimals, withComma } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Button } from '../../atom/Button';
 import '../../atom/Tabs/style.css';
@@ -291,13 +291,8 @@ const PositionItem = function (props: Props) {
       };
     }
     const pnlPercentage = divPreserved(
-      BigInt(position.pnl),
+      position.pnl,
       takerMargin,
-      PNL_RATE_DECIMALS + PERCENT_DECIMALS
-    );
-    const pnlAmount = mulPreserved(
-      position.collateral,
-      pnlPercentage,
       PNL_RATE_DECIMALS + PERCENT_DECIMALS
     );
     return {
@@ -310,7 +305,7 @@ const PositionItem = function (props: Props) {
       pnlPercentage: `${pnlPercentage > 0n ? '+' : ''}${withComma(
         formatDecimals(pnlPercentage, PNL_RATE_DECIMALS, 2)
       )}%`,
-      pnlAmount: formatUnits(pnlAmount, token.decimals),
+      pnlAmount: formatUnits(position.pnl, token.decimals),
       profitPrice: withComma(
         formatDecimals(abs(position.profitPrice), ORACLE_PROVIDER_DECIMALS, 2)
       ),

--- a/src/stories/template/TradeBar/index.tsx
+++ b/src/stories/template/TradeBar/index.tsx
@@ -21,7 +21,7 @@ import { TRADE_EVENT } from '~/typings/events';
 import { Market, Token } from '~/typings/market';
 import { OracleVersion } from '~/typings/oracleVersion';
 import { CLOSED, CLOSING, OPENED, OPENING, Position } from '~/typings/position';
-import { abs, divPreserved, formatDecimals, withComma } from '~/utils/number';
+import { abs, divPreserved, formatDecimals, mulPreserved, withComma } from '~/utils/number';
 import { isValid } from '~/utils/valid';
 import { Button } from '../../atom/Button';
 import '../../atom/Tabs/style.css';
@@ -268,7 +268,7 @@ const PositionItem = function (props: Props) {
       abs(qty) === 0n
         ? 0n
         : (makerMargin * parseUnits('1', QTY_DECIMALS) * 100n * 10000n) /
-          parseUnits(String(qty), token.decimals);
+          parseUnits(String(abs(qty)), token.decimals);
     const takeProfit = formatDecimals(takeProfitRaw, 4, 2) + '%';
     const currentOracleVersion = oracleVersions[position.marketAddress];
     if (
@@ -295,12 +295,10 @@ const PositionItem = function (props: Props) {
       takerMargin,
       PNL_RATE_DECIMALS + PERCENT_DECIMALS
     );
-    const pnlAmount = parseUnits(
-      formatUnits(
-        position.collateral * pnlPercentage,
-        token.decimals + PNL_RATE_DECIMALS + PERCENT_DECIMALS
-      ),
-      token.decimals
+    const pnlAmount = mulPreserved(
+      position.collateral,
+      pnlPercentage,
+      PNL_RATE_DECIMALS + PERCENT_DECIMALS
     );
     return {
       qty: withComma(formatDecimals(abs(qty), 4, 2)),

--- a/src/typings/position.ts
+++ b/src/typings/position.ts
@@ -38,5 +38,5 @@ export interface Position extends IChromaticPosition {
   toProfit: bigint;
   collateral: bigint;
   toLoss: bigint;
-  pnl: 0 | bigint;
+  pnl: bigint;
 }

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -156,28 +156,3 @@ export const toBigintWithDecimals = (value: number | string | bigint, decimals: 
 export const toBigInt = (value: number | string) => {
   return toBigintWithDecimals(value, 0);
 };
-
-export const fromExponentials = (value: number | string) => {
-  const [head, power = undefined] = String(value).split(/[eE]/);
-  if (isNil(power)) {
-    return head;
-  }
-  let converted = '';
-  const sign = Number(value) < 0 ? '-' : '';
-  const lead = head.replace('.', '');
-  let step = Number(power) + 1;
-
-  if (step < 0) {
-    converted = sign + '0.';
-    while (step++) {
-      converted += '0';
-    }
-    return converted + lead.replace(/^\-/, '');
-  } else {
-    step -= lead.length;
-    while (step--) {
-      converted += '0';
-    }
-    return lead + converted;
-  }
-};

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -137,8 +137,12 @@ export const decimalLength = (num: number | string, length: number, fix: boolean
   return result;
 };
 
-export const divPreserved = (valueA: bigint, valueB: bigint, preserved_decmials: number) => {
-  return (valueA * parseUnits('1', preserved_decmials)) / valueB;
+export const divPreserved = (numerator: bigint, denominator: bigint, decimals: number) => {
+  return (numerator * 10n ** BigInt(decimals)) / denominator;
+};
+
+export const mulPreserved = (value: bigint, numerator: bigint, decimals: number) => {
+  return (value * numerator) / 10n ** BigInt(decimals);
 };
 
 export const toBigintWithDecimals = (value: number | string | bigint, decimals: number) => {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -152,3 +152,28 @@ export const toBigintWithDecimals = (value: number | string | bigint, decimals: 
 export const toBigInt = (value: number | string) => {
   return toBigintWithDecimals(value, 0);
 };
+
+export const fromExponentials = (value: number | string) => {
+  const [head, power = undefined] = String(value).split(/[eE]/);
+  if (isNil(power)) {
+    return head;
+  }
+  let converted = '';
+  const sign = Number(value) < 0 ? '-' : '';
+  const lead = head.replace('.', '');
+  let step = Number(power) + 1;
+
+  if (step < 0) {
+    converted = sign + '0.';
+    while (step++) {
+      converted += '0';
+    }
+    return converted + lead.replace(/^\-/, '');
+  } else {
+    step -= lead.length;
+    while (step--) {
+      converted += '0';
+    }
+    return lead + converted;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@
     d3-scale "^4.0.2"
     react-compound-slider "^3.3.1"
 
-"@chromatic-protocol/sdk-viem@^0.1.0-rc.109":
-  version "0.1.0-rc.109"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.109.tgz#706fb1586c980836919fb153c1d1bdb4e8c0909f"
-  integrity sha512-kLLCgqcFzcXkCnhd24SCrpjULy8IvxBllcn6Jtocrm+XJ1PSO7FDgzTmiEnoWmUZ4dOWRutwCd/k7pScA1a9nw==
+"@chromatic-protocol/sdk-viem@^0.1.0-rc.110":
+  version "0.1.0-rc.110"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.110.tgz#107fcb2c187736cf5e655b71b5f25d7392af18db"
+  integrity sha512-J7YtiJ+HfG1E/e8tDUE1H3wdXlfY4Yhba6CjZQ0qOqPXZxq3cesVCxEvBjJZaiwhJm+Pp9T36iK31DsTzNfG3A==
   dependencies:
     viem "1.2.12"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@
     d3-scale "^4.0.2"
     react-compound-slider "^3.3.1"
 
-"@chromatic-protocol/sdk-viem@^0.1.0-rc.107":
-  version "0.1.0-rc.107"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.107.tgz#b8751a5c5c9145a003ee8470eb078d2af899a6ef"
-  integrity sha512-NZf/J70CVmShA86Eb2jdhefP3urNE0dJXh40CKHy7P4+RwKwd5llbu3AVV5PYCH5iPQFrBxEhsi4n1FTNNApIQ==
+"@chromatic-protocol/sdk-viem@^0.1.0-rc.109":
+  version "0.1.0-rc.109"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.109.tgz#706fb1586c980836919fb153c1d1bdb4e8c0909f"
+  integrity sha512-kLLCgqcFzcXkCnhd24SCrpjULy8IvxBllcn6Jtocrm+XJ1PSO7FDgzTmiEnoWmUZ4dOWRutwCd/k7pScA1a9nw==
   dependencies:
     viem "1.2.12"
 
@@ -10080,6 +10080,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

- Display `bigint` values without exponential style
- `NaN` errors
  - Fetch owned liquidity pools

- Division by zero
  - Removable, utilized amounts on `LiquidityItem`

- Take profit on `TradeBar`
  - Apply absolute values