### PR TITLE
fix: Frontend feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
-    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.112",
+    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.114",
     "@floating-ui/dom": "^1.4.2",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
-    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.114",
+    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.115",
     "@floating-ui/dom": "^1.4.2",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",

--- a/src/hooks/useTradeInput.ts
+++ b/src/hooks/useTradeInput.ts
@@ -26,6 +26,7 @@ const initialTradeInput = {
   takerMargin: 0,
   makerMargin: 0,
   leverage: '10',
+  maxFeeAllowance: 0.3,
 } satisfies TradeInput;
 
 // const trimDecimals = (num: number, decimals: number) => {
@@ -37,7 +38,7 @@ const tradeInputReducer = (state: TradeInput, action: TradeInputAction) => {
     const nextMethod = state.method === 'collateral' ? 'quantity' : 'collateral';
     switch (nextMethod) {
       case 'collateral': {
-        const { direction, collateral, leverage, takeProfit } = state;
+        const { direction, collateral, leverage, takeProfit, maxFeeAllowance } = state;
         const defaultLeverage = 2;
         if (Number(leverage) === 0) {
           state = {
@@ -50,6 +51,7 @@ const tradeInputReducer = (state: TradeInput, action: TradeInputAction) => {
             stopLoss: String(100 / defaultLeverage),
             takerMargin: Number(collateral),
             makerMargin: Number(collateral) * (Number(takeProfit) / 100) * defaultLeverage,
+            maxFeeAllowance,
           };
         } else {
           state = {
@@ -62,12 +64,13 @@ const tradeInputReducer = (state: TradeInput, action: TradeInputAction) => {
             stopLoss: String(100 / Number(leverage)),
             takerMargin: Number(collateral),
             makerMargin: Number(collateral) * (Number(takeProfit) / 100) * Number(leverage),
+            maxFeeAllowance,
           };
         }
         break;
       }
       case 'quantity': {
-        const { direction, quantity, leverage, takeProfit, stopLoss } = state;
+        const { direction, quantity, leverage, takeProfit, stopLoss, maxFeeAllowance } = state;
         state = {
           direction,
           method: nextMethod,
@@ -78,6 +81,7 @@ const tradeInputReducer = (state: TradeInput, action: TradeInputAction) => {
           leverage,
           takerMargin: Number(quantity) * (Number(stopLoss) / 100),
           makerMargin: Number(quantity) * (Number(takeProfit) / 100),
+          maxFeeAllowance,
         };
         break;
       }
@@ -171,6 +175,16 @@ const tradeInputReducer = (state: TradeInput, action: TradeInputAction) => {
       }
       break;
     }
+    case 'maxFeeAllowance': {
+      const { maxFeeAllowance } = payload;
+      if (maxFeeAllowance >= 0) {
+        state = {
+          ...state,
+          maxFeeAllowance,
+        };
+      }
+      break;
+    }
     case 'direction': {
       const { direction } = payload;
       state = {
@@ -256,7 +270,10 @@ export const useTradeInput = () => {
   };
 
   const onChange = (
-    key: keyof Omit<TradeInput, 'direction' | 'method' | 'takerMargin' | 'makerMargin'>,
+    key: keyof Omit<
+      TradeInput,
+      'direction' | 'method' | 'takerMargin' | 'makerMargin' | 'maxFeeAllowance'
+    >,
     newValue: string
   ) => {
     const value = newValue.replace(/,/g, '');

--- a/src/hooks/useTradeInput.ts
+++ b/src/hooks/useTradeInput.ts
@@ -418,8 +418,14 @@ export const useTradeInput = () => {
     if (isNaN(parsedTotalLiquidity)) return { status: true };
 
     const maxAmount =
-      Math.round(parsedTotalLiquidity) / Number(state.leverage) / (Number(state.takeProfit) / 100);
-    const amount = Number(state.collateral);
+      state.method === 'collateral'
+        ? Math.round(parsedTotalLiquidity) /
+          Number(state.leverage) /
+          (Number(state.takeProfit) / 100)
+        : Math.round(parsedTotalLiquidity) / (Number(state.takeProfit) / 100);
+
+    const amount =
+      state.method === 'collateral' ? Number(state.collateral) : Number(state.quantity);
 
     const balance = +(formatDecimals(totalMargin, token.decimals, 5) ?? '0');
 
@@ -430,7 +436,7 @@ export const useTradeInput = () => {
     } else {
       return { status: false };
     }
-  }, [state, longTotalUnusedLiquidity, shortTotalUnusedLiquidity, token, totalMargin]);
+  }, [state, longTotalUnusedLiquidity, shortTotalUnusedLiquidity]);
 
   return {
     state,

--- a/src/hooks/useTradeInput.ts
+++ b/src/hooks/useTradeInput.ts
@@ -349,14 +349,8 @@ export const useTradeInput = () => {
     if (isNaN(parsedTotalLiquidity)) return { status: true };
 
     const maxAmount =
-      state.method === 'collateral'
-        ? Math.round(parsedTotalLiquidity) /
-          Number(state.leverage) /
-          (Number(state.takeProfit) / 100)
-        : Math.round(parsedTotalLiquidity) / (Number(state.takeProfit) / 100);
-
-    const amount =
-      state.method === 'collateral' ? Number(state.collateral) : Number(state.quantity);
+      Math.round(parsedTotalLiquidity) / Number(state.leverage) / (Number(state.takeProfit) / 100);
+    const amount = Number(state.collateral);
 
     const balance = +(formatDecimals(totalMargin, token.decimals, 5) ?? '0');
 
@@ -367,7 +361,7 @@ export const useTradeInput = () => {
     } else {
       return { status: false };
     }
-  }, [state, longTotalUnusedLiquidity, shortTotalUnusedLiquidity]);
+  }, [state, longTotalUnusedLiquidity, shortTotalUnusedLiquidity, token, totalMargin]);
 
   return {
     state,

--- a/src/hooks/useUsumAccount.ts
+++ b/src/hooks/useUsumAccount.ts
@@ -39,6 +39,7 @@ export const useUsumAccount = () => {
     data: accountAddress,
     error,
     isLoading: isAccountAddressLoading,
+    mutate: fetchAddress,
   } = useSWR(checkAllProps(fetchKey) ? fetchKey : null, async ({ accountApi }) => {
     logger.info('account address fetch key ', fetchKey, client?.walletClient?.account?.address);
     try {
@@ -115,6 +116,7 @@ export const useUsumAccount = () => {
       logger.info('Creating accounts');
       setStatus(ACCOUNT_CREATING);
       await accountApi.createAccount();
+      await fetchAddress();
       setStatus(ACCOUNT_COMPLETING);
     } catch (error) {
       setStatus(ACCOUNT_NONE);

--- a/src/pages/trade/index.tsx
+++ b/src/pages/trade/index.tsx
@@ -65,6 +65,8 @@ const Trade = () => {
     onLeverageChange: onLongLeverageChange,
     onTakeProfitChange: onLongTakeProfitChange,
     onStopLossChange: onLongStopLossChange,
+    onFeeAllowanceChange: onLongFeeAllowanceChange,
+    onFeeAllowanceValidate: onLongFeeValidate,
   } = useTradeInput();
   const {
     state: shortInput,
@@ -77,6 +79,8 @@ const Trade = () => {
     onLeverageChange: onShortLeverageChange,
     onTakeProfitChange: onShortTakeProfitChange,
     onStopLossChange: onShortStopLossChange,
+    onFeeAllowanceChange: onShortFeeAllowanceChange,
+    onFeeAllowanceValidate: onShortFeeValidate,
   } = useTradeInput();
   const {
     liquidity: {
@@ -162,6 +166,8 @@ const Trade = () => {
             onLongLeverageChange={onLongLeverageChange}
             onLongTakeProfitChange={onLongTakeProfitChange}
             onLongStopLossChange={onLongStopLossChange}
+            onLongFeeValidate={onLongFeeValidate}
+            onLongFeeAllowanceChange={onLongFeeAllowanceChange}
             shortInput={shortInput}
             shortTradeFee={shortTradeFee}
             shortTradeFeePercent={shortFeePercent}
@@ -170,6 +176,8 @@ const Trade = () => {
             onShortLeverageChange={onShortLeverageChange}
             onShortTakeProfitChange={onShortTakeProfitChange}
             onShortStopLossChange={onShortStopLossChange}
+            onShortFeeValidate={onShortFeeValidate}
+            onShortFeeAllowanceChange={onShortFeeAllowanceChange}
             balances={balances}
             priceFeed={priceFeed}
             token={currentSelectedToken}

--- a/src/stories/atom/Input/index.tsx
+++ b/src/stories/atom/Input/index.tsx
@@ -4,8 +4,8 @@ import { ChangeEvent, useEffect, useState } from 'react';
 
 import { Avatar } from '~/stories/atom/Avatar';
 
-import { isValid } from '~/utils/valid';
 import { withComma } from '~/utils/number';
+import { isValid } from '~/utils/valid';
 
 interface InputProps {
   label?: string;

--- a/src/stories/atom/OptionInput/index.tsx
+++ b/src/stories/atom/OptionInput/index.tsx
@@ -1,8 +1,8 @@
+import { useState } from 'react';
+import '../../atom/Input/style.css';
+import { Button } from '../Button';
 import { Input } from '../Input';
 // import { Avatar } from "../Avatar";
-import { Button } from '../Button';
-import '../../atom/Input/style.css';
-import { useState } from 'react';
 
 interface OptionInputProps {
   label?: string;
@@ -39,6 +39,11 @@ export const OptionInput = (props: OptionInputProps) => {
   } = props;
   const [ratio, setRatio] = useState<25 | 50 | 75 | 100>();
   const onClick = (ratio: 25 | 50 | 75 | 100) => {
+    if (ratio === 100) {
+      setRatio(100);
+      onButtonClick?.(String(maxValue) ?? '');
+      return;
+    }
     const nextValue = (Number(maxValue) * (ratio / 100)).toString();
     setRatio(ratio);
     onButtonClick?.(nextValue ?? '');

--- a/src/stories/molecule/AccountPopover/index.tsx
+++ b/src/stories/molecule/AccountPopover/index.tsx
@@ -1,6 +1,7 @@
 import { Popover } from '@headlessui/react';
 import { ArrowTopRightOnSquareIcon, ChevronDoubleUpIcon } from '@heroicons/react/24/outline';
 import { isNotNil } from 'ramda';
+import { formatUnits } from 'viem';
 import { Loading } from '~/stories/atom/Loading';
 import { Outlink } from '~/stories/atom/Outlink';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
@@ -344,8 +345,8 @@ const AssetPanel = (props: AssetPanelProps) => {
                         maxValue={
                           token &&
                           (title === 'Deposit'
-                            ? formatDecimals(walletBalances?.[token.address], token?.decimals, 5)
-                            : formatDecimals(usumBalances?.[token.address], token?.decimals, 5))
+                            ? formatUnits(walletBalances?.[token.address] ?? 0n, token?.decimals)
+                            : formatUnits(usumBalances?.[token.address] ?? 0n, token?.decimals))
                         }
                         onChange={(value) => {
                           onAmountChange?.(value);

--- a/src/stories/molecule/PoolProgress/index.tsx
+++ b/src/stories/molecule/PoolProgress/index.tsx
@@ -14,7 +14,6 @@ import '../../atom/Tabs/style.css';
 // import { LPReceipt } from "~/typings/receipt";
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLastOracle } from '~/hooks/useLastOracle';
-import { usePrevious } from '~/hooks/usePrevious';
 import { POOL_EVENT } from '~/typings/events';
 import { Market, Token } from '~/typings/market';
 import { OracleVersion } from '~/typings/oracleVersion';
@@ -36,7 +35,7 @@ export const receiptDetail = (receipt: LpReceipt, token: Token) => {
   if (action === 'add') {
     return formatDecimals(receipt.amount, token.decimals, 2);
   }
-  const amountRatio = divPreserved(burningAmount, amount, 2);
+  const amountRatio = amount !== 0n ? divPreserved(burningAmount, amount, 2) : 0n;
   return `${formatDecimals(burningAmount, token.decimals, 2, true)} / ${formatDecimals(
     amount,
     token.decimals,
@@ -68,7 +67,6 @@ export const PoolProgress = ({
   onReceiptClaim,
   onReceiptClaimBatch,
 }: PoolProgressProps) => {
-  const previousReceipts = usePrevious(receipts, true);
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [hasGuide, setHasGuide] = useState(false);
@@ -80,7 +78,7 @@ export const PoolProgress = ({
   const { mintings, burnings } = useMemo(() => {
     let mintings = 0;
     let burnings = 0;
-    (receipts ?? previousReceipts).forEach((receipt) => {
+    receipts.forEach((receipt) => {
       if (receipt.action === 'add') {
         mintings++;
       } else {
@@ -191,7 +189,7 @@ export const PoolProgress = ({
                           </div>
                           {isValid(token) &&
                             isValid(market) &&
-                            (receipts || previousReceipts).map((receipt, index) => (
+                            receipts.map((receipt, index) => (
                               <ProgressItem
                                 key={`all-${receipt.id.toString()}-${index}`}
                                 // title={receipt.title}
@@ -230,7 +228,7 @@ export const PoolProgress = ({
                           </div>
                           {isValid(token) &&
                             isValid(market) &&
-                            (receipts || previousReceipts)
+                            receipts
                               .filter((receipt) => receipt.action === 'add')
                               .map((receipt, index) => (
                                 <ProgressItem
@@ -271,7 +269,7 @@ export const PoolProgress = ({
                           </div>
                           {isValid(token) &&
                             isValid(market) &&
-                            (receipts || previousReceipts)
+                            receipts
                               .filter((receipt) => receipt.action === 'remove')
                               .map((receipt, index) => (
                                 <ProgressItem

--- a/src/stories/molecule/TradeContent/index.tsx
+++ b/src/stories/molecule/TradeContent/index.tsx
@@ -376,7 +376,7 @@ export const TradeContent = ({ ...props }: TradeContentProps) => {
                 />
               </div>
               <div className="w-20">
-                <Input size="sm" unit="%" value={0.3} />
+                <Input size="sm" unit="%" value={input?.maxFeeAllowance} />
               </div>
             </div>
           </div>

--- a/src/stories/molecule/TradeContent/index.tsx
+++ b/src/stories/molecule/TradeContent/index.tsx
@@ -47,6 +47,8 @@ interface TradeContentProps {
   onLeverageChange?: (nextLeverage: string) => unknown;
   onTakeProfitChange?: (nextRate: string) => unknown;
   onStopLossChange?: (nextRate: string) => unknown;
+  onFeeAllowanceChange?: (nextAllowance: string) => unknown;
+  onFeeValidate?: () => unknown;
 }
 
 const methodMap: Record<string, string> = {
@@ -78,6 +80,8 @@ export const TradeContent = ({ ...props }: TradeContentProps) => {
     onLeverageChange,
     onTakeProfitChange,
     onStopLossChange,
+    onFeeAllowanceChange,
+    onFeeValidate,
   } = props;
 
   const oracleDecimals = 18;
@@ -155,6 +159,22 @@ export const TradeContent = ({ ...props }: TradeContentProps) => {
   useEffect(() => {
     createLiquidation();
   }, [createLiquidation]);
+
+  useEffect(() => {
+    const input = document.querySelector('.maxFeeAllowance');
+    const onClickAway = (event: MouseEvent) => {
+      if (!(event.target instanceof HTMLElement)) {
+        return;
+      }
+      if (!input?.contains(event.target)) {
+        onFeeValidate?.();
+      }
+    };
+    window.addEventListener('click', onClickAway);
+    return () => {
+      window.removeEventListener('click', onClickAway);
+    };
+  }, [onFeeValidate]);
 
   return (
     <div className="px-10 w-full max-w-[680px]">
@@ -376,7 +396,15 @@ export const TradeContent = ({ ...props }: TradeContentProps) => {
                 />
               </div>
               <div className="w-20">
-                <Input size="sm" unit="%" value={input?.maxFeeAllowance} />
+                <Input
+                  size="sm"
+                  unit="%"
+                  value={input?.maxFeeAllowance}
+                  className="maxFeeAllowance"
+                  onChange={(value) => {
+                    onFeeAllowanceChange?.(value);
+                  }}
+                />
               </div>
             </div>
           </div>

--- a/src/stories/template/PoolPanel/index.tsx
+++ b/src/stories/template/PoolPanel/index.tsx
@@ -177,7 +177,7 @@ export const PoolPanel = (props: PoolPanelProps) => {
   const onSelectAllClick = useCallback(
     (selectedIndex: number) => {
       switch (selectedIndex) {
-        case 0: {
+        case 1: {
           if (
             direction === 'long' &&
             selectedBins.filter((bin) => bin.baseFeeRate > 0).length ===
@@ -189,7 +189,7 @@ export const PoolPanel = (props: PoolPanelProps) => {
           }
           break;
         }
-        case 1: {
+        case 0: {
           if (
             direction === 'short' &&
             selectedBins.filter((bin) => bin.baseFeeRate < 0).length ===
@@ -515,8 +515,8 @@ export const PoolPanel = (props: PoolPanelProps) => {
                     <>
                       <div className="flex flex-wrap items-baseline">
                         <Tab.List className="pt-[36px] !justify-start !gap-10">
-                          <Tab>Long LP</Tab>
                           <Tab>Short LP</Tab>
+                          <Tab>Long LP</Tab>
                         </Tab.List>
 
                         {/* todo: hide buttons&wrapper when there is no list */}
@@ -536,7 +536,9 @@ export const PoolPanel = (props: PoolPanelProps) => {
                             css="gray"
                             className="ml-2"
                             onClick={() => {
-                              dispatch(poolsAction.onModalOpen());
+                              if (selectedBins.length > 0) {
+                                dispatch(poolsAction.onModalOpen());
+                              }
                             }}
                             // disabled
                           />
@@ -545,13 +547,13 @@ export const PoolPanel = (props: PoolPanelProps) => {
                       <Tab.Panels className="mt-12">
                         <Tab.Panel>
                           <article>
-                            {ownedLongLiquidityBins?.length === 0 ? (
+                            {ownedShortLiquidityBins.length === 0 ? (
                               <p className="my-10 text-center text-gray">
                                 You have no liquidity yet.
                               </p>
                             ) : (
                               <div className="flex flex-col gap-3">
-                                {ownedLongLiquidityBins.map((bin, binIndex) => (
+                                {ownedShortLiquidityBins.map((bin, binIndex) => (
                                   <BinItem
                                     key={bin.baseFeeRate}
                                     index={binIndex}
@@ -569,13 +571,13 @@ export const PoolPanel = (props: PoolPanelProps) => {
                         </Tab.Panel>
                         <Tab.Panel>
                           <article>
-                            {ownedShortLiquidityBins.length === 0 ? (
+                            {ownedLongLiquidityBins?.length === 0 ? (
                               <p className="my-10 text-center text-gray">
                                 You have no liquidity yet.
                               </p>
                             ) : (
                               <div className="flex flex-col gap-3">
-                                {ownedShortLiquidityBins.map((bin, binIndex) => (
+                                {ownedLongLiquidityBins.map((bin, binIndex) => (
                                   <BinItem
                                     key={bin.baseFeeRate}
                                     index={binIndex}

--- a/src/stories/template/RemoveLiquidityModal/index.tsx
+++ b/src/stories/template/RemoveLiquidityModal/index.tsx
@@ -176,7 +176,6 @@ export const RemoveLiquidityModal = (props: RemoveLiquidityModalProps) => {
               onClick={async () => {
                 if (isValid(selectedBin) && isValid(amount)) {
                   onRemoveLiquidity();
-                  onAmountChange?.('0');
                 }
               }}
             />

--- a/src/stories/template/TradeBar/index.tsx
+++ b/src/stories/template/TradeBar/index.tsx
@@ -266,6 +266,7 @@ const PositionItem = function (props: Props) {
         profitPrice: '-',
         entryPrice: '-',
         entryTime: '-',
+        pnlAmount: '-',
       };
     }
     const { collateral, qty, leverage, makerMargin, takerMargin } = position;
@@ -294,6 +295,7 @@ const PositionItem = function (props: Props) {
         profitPrice: '-',
         entryPrice: '-',
         entryTime: '-',
+        pnlAmount: '-',
       };
     }
     const pnlPercentage = divPreserved(
@@ -314,10 +316,10 @@ const PositionItem = function (props: Props) {
         2,
         true
       )}%`,
-      pnlAmount: formatDecimals(position.pnl, token.decimals, 2, true),
+      pnlAmount: formatDecimals(position.pnl, token.decimals, 2, true) + ' ' + token.name,
       profitPrice: formatDecimals(abs(position.profitPrice), ORACLE_PROVIDER_DECIMALS, 2, true),
       lossPrice: formatDecimals(abs(position.lossPrice), ORACLE_PROVIDER_DECIMALS, 2, true),
-      entryPrice: formatDecimals(position.openPrice, ORACLE_PROVIDER_DECIMALS, 2, true),
+      entryPrice: '$ ' + formatDecimals(position.openPrice, ORACLE_PROVIDER_DECIMALS, 2, true),
       entryTime: new Intl.DateTimeFormat('en-US', {
         month: 'long',
         day: 'numeric',
@@ -376,7 +378,7 @@ const PositionItem = function (props: Props) {
           <div className="flex items-center gap-8 pl-6 border-l">
             <p className="text-black/50">Entry Price</p>
             <SkeletonElement isLoading={isLoading} width={60}>
-              ${calculated.entryPrice}
+              {calculated.entryPrice}
             </SkeletonElement>
           </div>
           <div className="flex items-center gap-8 pl-6 border-l">
@@ -485,7 +487,7 @@ const PositionItem = function (props: Props) {
               isLoading={isLoading}
             />
             {/* todo: add PnL price (has no label, value only) */}
-            <TextRow value={calculated.pnlAmount + ' ' + token?.name} isLoading={isLoading} />
+            <TextRow value={calculated.pnlAmount} isLoading={isLoading} />
           </div>
         </div>
         <div className="w-[10%] min-w-[140px] flex flex-col items-center justify-center gap-2 pl-6 border-l">

--- a/src/stories/template/TradePanel/index.tsx
+++ b/src/stories/template/TradePanel/index.tsx
@@ -1,5 +1,5 @@
 import { Tab } from '@headlessui/react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { LONG_TAB, POSITION_TAB, SHORT_TAB } from '~/configs/tab';
 import { CurvedButton } from '~/stories/atom/CurvedButton';
 import '~/stories/atom/Tabs/style.css';
@@ -20,6 +20,8 @@ export interface TradePanelProps {
   onLongLeverageChange?: (value: string) => unknown;
   onLongTakeProfitChange?: (value: string) => unknown;
   onLongStopLossChange?: (value: string) => unknown;
+  onLongFeeAllowanceChange?: (value: string) => unknown;
+  onLongFeeValidate?: () => unknown;
 
   shortInput?: TradeInput;
   shortTradeFee?: bigint;
@@ -32,6 +34,8 @@ export interface TradePanelProps {
   onShortLeverageChange?: (value: string) => unknown;
   onShortTakeProfitChange?: (value: string) => unknown;
   onShortStopLossChange?: (value: string) => unknown;
+  onShortFeeAllowanceChange?: (value: string) => unknown;
+  onShortFeeValidate?: () => unknown;
 
   balances?: Record<string, bigint>;
   priceFeed?: Record<string, Price>;
@@ -66,6 +70,8 @@ export const TradePanel = (props: TradePanelProps) => {
     onLongLeverageChange,
     onLongTakeProfitChange,
     onLongStopLossChange,
+    onLongFeeAllowanceChange,
+    onLongFeeValidate,
     shortInput,
     shortTradeFee,
     shortTradeFeePercent,
@@ -74,6 +80,8 @@ export const TradePanel = (props: TradePanelProps) => {
     onShortLeverageChange,
     onShortTakeProfitChange,
     onShortStopLossChange,
+    onShortFeeAllowanceChange,
+    onShortFeeValidate,
     balances,
     priceFeed,
     token,
@@ -149,6 +157,8 @@ export const TradePanel = (props: TradePanelProps) => {
                 onLeverageChange={onShortLeverageChange}
                 onTakeProfitChange={onShortTakeProfitChange}
                 onStopLossChange={onShortStopLossChange}
+                onFeeAllowanceChange={onShortFeeAllowanceChange}
+                onFeeValidate={onShortFeeValidate}
               />
             </div>
             <div className="w-full px-0 pt-4 pb-10">
@@ -179,6 +189,8 @@ export const TradePanel = (props: TradePanelProps) => {
                 onLeverageChange={onLongLeverageChange}
                 onTakeProfitChange={onLongTakeProfitChange}
                 onStopLossChange={onLongStopLossChange}
+                onFeeAllowanceChange={onLongFeeAllowanceChange}
+                onFeeValidate={onLongFeeValidate}
               />
             </div>
           </div>
@@ -247,6 +259,8 @@ export const TradePanel = (props: TradePanelProps) => {
                     onLeverageChange={onShortLeverageChange}
                     onTakeProfitChange={onShortTakeProfitChange}
                     onStopLossChange={onShortStopLossChange}
+                    onFeeAllowanceChange={onShortFeeAllowanceChange}
+                    onFeeValidate={onShortFeeValidate}
                   />
                 </Tab.Panel>
                 <Tab.Panel className="w-full px-0 pb-10 pt-7">
@@ -272,6 +286,8 @@ export const TradePanel = (props: TradePanelProps) => {
                     onLeverageChange={onLongLeverageChange}
                     onTakeProfitChange={onLongTakeProfitChange}
                     onStopLossChange={onLongStopLossChange}
+                    onFeeAllowanceChange={onLongFeeAllowanceChange}
+                    onFeeValidate={onLongFeeValidate}
                   />
                 </Tab.Panel>
               </Tab.Panels>

--- a/src/stories/template/TradePanel/stories.ts
+++ b/src/stories/template/TradePanel/stories.ts
@@ -29,7 +29,7 @@ export const Default: Story = {
       takerMargin: 0,
       makerMargin: 0,
       leverage: '1',
-      maxFeeAllowance: 0.3,
+      maxFeeAllowance: '0.3',
     },
     shortInput: {
       direction: 'short',
@@ -41,7 +41,7 @@ export const Default: Story = {
       takerMargin: 0,
       makerMargin: 0,
       leverage: '1',
-      maxFeeAllowance: 0.3,
+      maxFeeAllowance: '0.3',
     },
     balances: {
       USDC: 1000n,

--- a/src/stories/template/TradePanel/stories.ts
+++ b/src/stories/template/TradePanel/stories.ts
@@ -29,6 +29,7 @@ export const Default: Story = {
       takerMargin: 0,
       makerMargin: 0,
       leverage: '1',
+      maxFeeAllowance: 0.3,
     },
     shortInput: {
       direction: 'short',
@@ -40,6 +41,7 @@ export const Default: Story = {
       takerMargin: 0,
       makerMargin: 0,
       leverage: '1',
+      maxFeeAllowance: 0.3,
     },
     balances: {
       USDC: 1000n,
@@ -54,6 +56,6 @@ export const Default: Story = {
     shortTotalMaxLiquidity: 10000n,
     shortTotalUnusedLiquidity: 10000n,
     isLongDisabled: false,
-    isShortDisabled: false
+    isShortDisabled: false,
   },
 };

--- a/src/typings/trade.ts
+++ b/src/typings/trade.ts
@@ -8,7 +8,7 @@ export interface TradeInput {
   takerMargin: number;
   makerMargin: number;
   leverage: string;
-  maxFeeAllowance: number;
+  maxFeeAllowance: string;
 }
 
 export type TradeInputAction<T = keyof TradeInput> = T extends keyof TradeInput

--- a/src/typings/trade.ts
+++ b/src/typings/trade.ts
@@ -8,6 +8,7 @@ export interface TradeInput {
   takerMargin: number;
   makerMargin: number;
   leverage: string;
+  maxFeeAllowance: number;
 }
 
 export type TradeInputAction<T = keyof TradeInput> = T extends keyof TradeInput

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@
     d3-scale "^4.0.2"
     react-compound-slider "^3.3.1"
 
-"@chromatic-protocol/sdk-viem@^0.1.0-rc.112":
-  version "0.1.0-rc.112"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.112.tgz#a0581213eb7df0ff7543d61f5e871c390a9adf48"
-  integrity sha512-Cw9pRG2KZKshoJbpdFigS+qfrHDTXPzLZhsJR4H9Zw7hhO0HytJ0gogfm4XP06kqdgLZkwG1uFvHfmwlb4Q7Yg==
+"@chromatic-protocol/sdk-viem@^0.1.0-rc.114":
+  version "0.1.0-rc.114"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.114.tgz#f4f7d567c2649c7593442f75a79318522778d970"
+  integrity sha512-DArmyiv2qiAILtsnosQESXIw42BPFW5D1bopfO5ovJRI7VOaR7pRB1QH3fRSux7RWp7lDVYvAhiUrEtzFZgMSg==
   dependencies:
     viem "1.2.12"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,10 +1427,10 @@
     d3-scale "^4.0.2"
     react-compound-slider "^3.3.1"
 
-"@chromatic-protocol/sdk-viem@^0.1.0-rc.114":
-  version "0.1.0-rc.114"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.114.tgz#f4f7d567c2649c7593442f75a79318522778d970"
-  integrity sha512-DArmyiv2qiAILtsnosQESXIw42BPFW5D1bopfO5ovJRI7VOaR7pRB1QH3fRSux7RWp7lDVYvAhiUrEtzFZgMSg==
+"@chromatic-protocol/sdk-viem@^0.1.0-rc.115":
+  version "0.1.0-rc.115"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.115.tgz#eeb6ec9aa16c78872aacd0c9f24fd36d8d123d3e"
+  integrity sha512-QczPKc0jC+bYPtjEhh/WDQoyvuPl+8Jka9DfhnNDNM5/XZSG6zZlCVJd1ZNXk5J/HD6UZV8IUnTjVkBXtb67Pw==
   dependencies:
     viem "1.2.12"
 


### PR DESCRIPTION
## Description

- Trade
  - Input max fee allowance
    - Used to open positions
  - Automatically changed by trade fee
  - Show PnL amount when undefined

- Liquidity
  - Reversed two tabs `Short LP`, and `Long LP`
  - Show remove modal when clicking `Remove selected`
    - Already selected bins needed.

  - Show toast components when error occurs on claiming multiple receipts

- Account
  - Fetch contract address again after creating account.
  - Deposit or Withdraw with max amounts

## Related issues

- Fixes #389 