### PR TITLE
fix: Add pagination to logs like `Trade`, and `History`

### DIFF
--- a/src/constants/arbiscan.ts
+++ b/src/constants/arbiscan.ts
@@ -9,4 +9,4 @@ export const ARBISCAN_API_URLS = {
 export const ARBISCAN_API_URL = ARBISCAN_API_URLS[CHAIN];
 export const ARBISCAN_API_KEY = import.meta.env.VITE_ARBISCAN_KEY;
 export const BLOCK_CHUNK = 1000000n;
-export const PAGE_SIZE = 10;
+export const PAGE_SIZE = 5;

--- a/src/constants/arbiscan.ts
+++ b/src/constants/arbiscan.ts
@@ -1,0 +1,12 @@
+import { CHAIN } from './contracts';
+
+export const ARBISCAN_API_URLS = {
+  anvil: undefined,
+  arbitrum_goerli: 'https://api-goerli.arbiscan.io',
+  arbitrum_one: 'https://api.arbiscan.io',
+};
+
+export const ARBISCAN_API_URL = ARBISCAN_API_URLS[CHAIN];
+export const ARBISCAN_API_KEY = import.meta.env.VITE_ARBISCAN_KEY;
+export const BLOCK_CHUNK = 1000000n;
+export const PAGE_SIZE = 10;

--- a/src/hooks/useInitialBlockNumber.ts
+++ b/src/hooks/useInitialBlockNumber.ts
@@ -1,0 +1,36 @@
+import { chromaticAccountABI } from '@chromatic-protocol/sdk-viem/contracts';
+import useSWR from 'swr';
+import { getEventSelector } from 'viem';
+import { ARBISCAN_API_KEY, ARBISCAN_API_URL } from '~/constants/arbiscan';
+import { ResponseLog } from '~/typings/position';
+import { checkAllProps } from '~/utils';
+import { useChromaticAccount } from './useChromaticAccount';
+import { useError } from './useError';
+
+const eventSignature = getEventSelector({
+  name: 'OpenPosition',
+  type: 'event',
+  inputs: chromaticAccountABI.find((abiItem) => abiItem.name === 'OpenPosition')!.inputs,
+});
+
+export const useInitialBlockNumber = () => {
+  const { accountAddress } = useChromaticAccount();
+  const fetchKey = { accountAddress, key: 'fetchInitialLogBlockNumber' };
+
+  const { data: initialBlockNumber, error } = useSWR(
+    checkAllProps(fetchKey) ? fetchKey : undefined,
+    async ({ accountAddress }) => {
+      const apiUrl = `${ARBISCAN_API_URL}/api?module=logs&action=getLogs&address=${accountAddress}&topic0=${eventSignature}&page=1&offset=1&apikey=${ARBISCAN_API_KEY}`;
+      const apiResponse = await fetch(apiUrl);
+      const apiData = await apiResponse.json();
+      const initialLog: ResponseLog[] = apiData.result;
+      if (initialLog.length <= 0) {
+        return undefined;
+      }
+      return BigInt(initialLog[0].blockNumber);
+    }
+  );
+
+  useError({ error });
+  return { initialBlockNumber };
+};

--- a/src/hooks/useMargins.ts
+++ b/src/hooks/useMargins.ts
@@ -11,7 +11,7 @@ export function useMargins() {
 
   const [totalBalance, totalAsset] = useMemo(() => {
     if (isNil(balances) || isNil(currentToken) || Object.keys(balances).length <= 0) {
-      return [undefined, undefined];
+      return [0n, 0n];
     }
     const balance = balances[currentToken.address];
     if (isNil(currentPositions)) {
@@ -30,7 +30,7 @@ export function useMargins() {
     if (isNil(balances) || isNil(currentToken)) {
       return 0n;
     }
-    return balances[currentToken.address];
+    return balances[currentToken.address] ?? 0n;
   }, [balances, currentToken]);
 
   return {

--- a/src/hooks/useTradeHistory.ts
+++ b/src/hooks/useTradeHistory.ts
@@ -108,12 +108,18 @@ export const useTradeHistory = () => {
           throw new Error('Invalid block number bounds');
         }
       }
+      const filteredMarkets =
+        filterOption === 'ALL'
+          ? entireMarkets
+          : filterOption === 'TOKEN_BASED'
+          ? markets
+          : markets.filter((market) => market.address === currentMarket?.address);
       let historyResult = [] as History[];
       while (true) {
         await new Promise((resolve) =>
           setTimeout(() => {
             resolve(undefined!);
-          }, 500)
+          }, 1000)
         );
         const fromBlockNumber: bigint =
           toBlockNumber - BLOCK_CHUNK > initialBlockNumber
@@ -142,7 +148,7 @@ export const useTradeHistory = () => {
             (history, decoded) => {
               const { positionId, marketAddress } = decoded.args;
               const { eventName, blockNumber } = decoded;
-              const selectedMarket = entireMarkets.find(
+              const selectedMarket = filteredMarkets.find(
                 (market) => market.address === marketAddress
               );
               const selectedToken = tokens?.find(

--- a/src/hooks/useTradeLogs.ts
+++ b/src/hooks/useTradeLogs.ts
@@ -1,0 +1,220 @@
+import { chromaticAccountABI } from '@chromatic-protocol/sdk-viem/contracts';
+import { isNil, isNotNil } from 'ramda';
+import useSWR from 'swr';
+import useSWRInfinite from 'swr/infinite';
+import { decodeEventLog, getEventSelector } from 'viem';
+import { ARBISCAN_API_KEY, ARBISCAN_API_URL, BLOCK_CHUNK, PAGE_SIZE } from '~/constants/arbiscan';
+import { Market, Token } from '~/typings/market';
+import { ResponseLog } from '~/typings/position';
+import { checkAllProps } from '~/utils';
+import { abs, divPreserved } from '~/utils/number';
+import { PromiseOnlySuccess } from '~/utils/promise';
+import { useChromaticAccount } from './useChromaticAccount';
+import { useChromaticClient } from './useChromaticClient';
+import { useError } from './useError';
+import { useEntireMarkets, useMarket } from './useMarket';
+import { usePositionFilter } from './usePositionFilter';
+import { useSettlementToken } from './useSettlementToken';
+
+type Trade = {
+  positionId: bigint;
+  token: Token;
+  market: Market;
+  entryPrice: bigint;
+  direction: 'long' | 'short';
+  collateral: bigint;
+  qty: bigint;
+  leverage: bigint;
+  entryTimestamp: bigint;
+  blockNumber: bigint;
+};
+
+export const useTradeLogs = () => {
+  const { isReady, client } = useChromaticClient();
+  const { accountAddress } = useChromaticAccount();
+  const { tokens } = useSettlementToken();
+  const { markets, currentMarket } = useMarket();
+  const { markets: entireMarkets } = useEntireMarkets();
+  const { filterOption } = usePositionFilter();
+
+  const { data: initialBlockNumber } = useSWR(
+    isNotNil(accountAddress) ? { accountAddress, key: 'fetchInitialLogBlockNumber' } : undefined,
+    async ({ accountAddress }) => {
+      const eventSignature = getEventSelector({
+        name: 'OpenPosition',
+        type: 'event',
+        inputs: chromaticAccountABI.find((abiItem) => abiItem.name === 'OpenPosition')!.inputs,
+      });
+      const apiUrl = `${ARBISCAN_API_URL}/api?module=logs&action=getLogs&address=${accountAddress}&topic0=${eventSignature}&page=1&offset=1&apikey=${ARBISCAN_API_KEY}`;
+      const apiResponse = await fetch(apiUrl);
+      const apiData = await apiResponse.json();
+      const initialLog: ResponseLog[] = apiData.result;
+      if (initialLog.length <= 0) {
+        return undefined;
+      }
+      return BigInt(initialLog[0].blockNumber);
+    }
+  );
+
+  const {
+    data: tradesData,
+    isLoading,
+    error,
+    size,
+    setSize,
+  } = useSWRInfinite(
+    (pageIndex, previousData) => {
+      if (!isReady || isNil(initialBlockNumber)) {
+        return null;
+      }
+      const fetchKey = {
+        key: 'fetchTradeLogs',
+        accountAddress,
+        tokens,
+        markets,
+        entireMarkets,
+        currentMarket,
+        filterOption,
+        initialBlockNumber,
+      };
+      if (!checkAllProps(fetchKey)) {
+        return;
+      }
+      if (previousData?.toBlockNumber < initialBlockNumber) {
+        return null;
+      }
+      return checkAllProps(fetchKey)
+        ? { ...fetchKey, toBlockNumber: previousData?.toBlockNumber as bigint | undefined }
+        : null;
+    },
+    async ({
+      accountAddress,
+      tokens,
+      markets,
+      entireMarkets,
+      currentMarket,
+      filterOption,
+      initialBlockNumber,
+      toBlockNumber,
+    }) => {
+      const eventSignature = getEventSelector({
+        name: 'OpenPosition',
+        type: 'event',
+        inputs: chromaticAccountABI.find((abiItem) => abiItem.name === 'OpenPosition')!.inputs,
+      });
+      if (isNil(toBlockNumber)) {
+        toBlockNumber = await client.publicClient?.getBlockNumber();
+        if (isNil(toBlockNumber)) {
+          throw new Error('Invalid block number bounds');
+        }
+      }
+      let logs = [] as ResponseLog[];
+      while (true) {
+        await new Promise((resolve) =>
+          setTimeout(() => {
+            resolve(undefined!);
+          }, 500)
+        );
+        const fromBlockNumber: bigint =
+          toBlockNumber - BLOCK_CHUNK > initialBlockNumber
+            ? toBlockNumber - BLOCK_CHUNK
+            : initialBlockNumber;
+        const apiUrl = `${ARBISCAN_API_URL}/api?module=logs&action=getLogs&address=${accountAddress}&topic0=${eventSignature}&fromBlock=${fromBlockNumber}&toBlock=${Number(
+          toBlockNumber
+        )}&apikey=${ARBISCAN_API_KEY}`;
+        const response = await fetch(apiUrl);
+        const responseData = await response.json();
+        const responseLogs =
+          typeof responseData.result === 'string' ? [] : (responseData.result as ResponseLog[]);
+        responseLogs.sort((previous, next) => (previous.blockNumber < next.blockNumber ? 1 : -1));
+        const totalLength = logs.length + responseLogs.length;
+        if (totalLength > PAGE_SIZE) {
+          const slicedLogs = responseLogs.slice(0, PAGE_SIZE - responseLogs.length);
+          const newToBlockNumber = slicedLogs[slicedLogs.length - 1].blockNumber;
+          logs = logs.concat(slicedLogs);
+          toBlockNumber = BigInt(newToBlockNumber) - 1n;
+          break;
+        } else if (totalLength === PAGE_SIZE) {
+          logs = logs.concat(responseLogs);
+          toBlockNumber = fromBlockNumber - 1n;
+          break;
+        } else {
+          logs = logs.concat(responseLogs);
+          toBlockNumber = fromBlockNumber - 1n;
+          if (fromBlockNumber === initialBlockNumber) {
+            break;
+          }
+        }
+      }
+      const decodedLogs = logs.map((log) => {
+        return {
+          ...decodeEventLog({
+            abi: chromaticAccountABI,
+            data: log.data,
+            topics: log.topics,
+            eventName: 'OpenPosition',
+          }).args,
+          blockNumber: BigInt(log.blockNumber),
+        };
+      });
+      const tradeLogsPromise = decodedLogs.map(async (decodedArg) => {
+        const {
+          positionId,
+          qty,
+          takerMargin,
+          marketAddress,
+          openTimestamp,
+          openVersion,
+          blockNumber,
+        } = decodedArg;
+        const selectedMarket = entireMarkets.find((market) => market.address === marketAddress);
+        const selectedToken = tokens.find(
+          (token) => token.address === selectedMarket?.tokenAddress
+        );
+        if (isNil(selectedMarket) || isNil(selectedToken)) {
+          throw new Error('Invalid logs');
+        }
+        const oracleProvider = await client
+          .market()
+          .contracts()
+          .oracleProvider(selectedMarket.address);
+        const entryOracle = await oracleProvider.read.atVersion([openVersion + 1n]);
+        return {
+          positionId,
+          token: selectedToken,
+          market: selectedMarket,
+          qty: abs(qty),
+          collateral: takerMargin,
+          leverage: divPreserved(qty, takerMargin, selectedToken.decimals),
+          direction: qty > 0n ? 'long' : 'short',
+          entryTimestamp: openTimestamp,
+          entryPrice: entryOracle.price,
+          blockNumber,
+        } satisfies Trade;
+      });
+      const resolvedLogs = await PromiseOnlySuccess(tradeLogsPromise);
+      return {
+        tradeLogs: resolvedLogs,
+        toBlockNumber,
+      };
+    },
+    {
+      refreshInterval: 0,
+      refreshWhenHidden: false,
+      revalidateOnFocus: false,
+      revalidateFirstPage: false,
+    }
+  );
+
+  const onFetchNextTrade = () => {
+    setSize(size + 1);
+  };
+
+  useError({ error });
+
+  return {
+    tradesData,
+    isLoading,
+    onFetchNextTrade,
+  };
+};

--- a/src/hooks/useTradeLogs.ts
+++ b/src/hooks/useTradeLogs.ts
@@ -1,7 +1,6 @@
 import { Client } from '@chromatic-protocol/sdk-viem';
 import { chromaticAccountABI } from '@chromatic-protocol/sdk-viem/contracts';
-import { isNil, isNotNil } from 'ramda';
-import useSWR from 'swr';
+import { isNil } from 'ramda';
 import useSWRInfinite from 'swr/infinite';
 import { decodeEventLog, getEventSelector } from 'viem';
 import { Address } from 'wagmi';
@@ -14,6 +13,7 @@ import { PromiseOnlySuccess } from '~/utils/promise';
 import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
 import { useError } from './useError';
+import { useInitialBlockNumber } from './useInitialBlockNumber';
 import { useEntireMarkets, useMarket } from './useMarket';
 import { usePositionFilter } from './usePositionFilter';
 import { useSettlementToken } from './useSettlementToken';
@@ -101,25 +101,7 @@ export const useTradeLogs = () => {
   const { markets, currentMarket } = useMarket();
   const { markets: entireMarkets } = useEntireMarkets();
   const { filterOption } = usePositionFilter();
-
-  const { data: initialBlockNumber } = useSWR(
-    isNotNil(accountAddress) ? { accountAddress, key: 'fetchInitialLogBlockNumber' } : undefined,
-    async ({ accountAddress }) => {
-      const eventSignature = getEventSelector({
-        name: 'OpenPosition',
-        type: 'event',
-        inputs: chromaticAccountABI.find((abiItem) => abiItem.name === 'OpenPosition')!.inputs,
-      });
-      const apiUrl = `${ARBISCAN_API_URL}/api?module=logs&action=getLogs&address=${accountAddress}&topic0=${eventSignature}&page=1&offset=1&apikey=${ARBISCAN_API_KEY}`;
-      const apiResponse = await fetch(apiUrl);
-      const apiData = await apiResponse.json();
-      const initialLog: ResponseLog[] = apiData.result;
-      if (initialLog.length <= 0) {
-        return undefined;
-      }
-      return BigInt(initialLog[0].blockNumber);
-    }
-  );
+  const { initialBlockNumber } = useInitialBlockNumber();
 
   const {
     data: tradesData,

--- a/src/hooks/useTradeLogs.ts
+++ b/src/hooks/useTradeLogs.ts
@@ -5,9 +5,10 @@ import useSWRInfinite from 'swr/infinite';
 import { decodeEventLog, getEventSelector } from 'viem';
 import { Address } from 'wagmi';
 import { ARBISCAN_API_KEY, ARBISCAN_API_URL, BLOCK_CHUNK, PAGE_SIZE } from '~/constants/arbiscan';
-import { Market, Token } from '~/typings/market';
+import { MarketLike, Token } from '~/typings/market';
 import { ResponseLog } from '~/typings/position';
 import { checkAllProps } from '~/utils';
+import { trimMarket, trimMarkets } from '~/utils/market';
 import { abs, divPreserved } from '~/utils/number';
 import { PromiseOnlySuccess } from '~/utils/promise';
 import { useChromaticAccount } from './useChromaticAccount';
@@ -21,7 +22,7 @@ import { useSettlementToken } from './useSettlementToken';
 type Trade = {
   positionId: bigint;
   token: Token;
-  market: Market;
+  market: MarketLike;
   entryPrice: bigint;
   direction: 'long' | 'short';
   collateral: bigint;
@@ -35,7 +36,7 @@ type GetTradeLogsParams = {
   toBlockNumber: bigint;
   initialBlockNumber: bigint;
   accountAddress: Address;
-  markets: Market[];
+  markets: MarketLike[];
   tokens: Token[];
   client: Client;
 };
@@ -118,9 +119,9 @@ export const useTradeLogs = () => {
         key: 'fetchTradeLogs',
         accountAddress,
         tokens,
-        markets,
-        entireMarkets,
-        currentMarket,
+        markets: trimMarkets(markets),
+        entireMarkets: trimMarkets(entireMarkets),
+        currentMarket: trimMarket(currentMarket),
         filterOption,
         initialBlockNumber,
       };
@@ -168,7 +169,7 @@ export const useTradeLogs = () => {
           toBlockNumber,
           initialBlockNumber,
           accountAddress,
-          markets,
+          markets: filteredMarkets,
           tokens,
           client,
         });
@@ -205,7 +206,7 @@ export const useTradeLogs = () => {
   );
 
   const onFetchNextTrade = () => {
-    setSize(size + 1);
+    setSize((size) => size + 1);
   };
 
   useError({ error });

--- a/src/stories/atom/Tag/index.tsx
+++ b/src/stories/atom/Tag/index.tsx
@@ -1,7 +1,7 @@
 import './style.css';
 
 interface TagProps {
-  label: string;
+  label?: string;
   size?: 'xs' | 'sm' | 'base' | 'lg' | 'xl';
   className?: string;
   onClick?: () => unknown;

--- a/src/stories/molecule/HistoryItem/index.tsx
+++ b/src/stories/molecule/HistoryItem/index.tsx
@@ -5,7 +5,8 @@ import { TradeHistory } from '~/typings/position';
 
 export interface HistoryItemProps {
   isLoading: boolean;
-  history: TradeHistory;
+  history?: TradeHistory;
+  onLoadRef?: (element: HTMLDivElement | null) => unknown;
 }
 
 export function HistoryItem(props: HistoryItemProps) {
@@ -23,12 +24,13 @@ export function HistoryItem(props: HistoryItemProps) {
       pnl,
       pnlRate,
       pnlClass,
-    },
+    } = {},
     isLoading,
+    onLoadRef,
   } = props;
 
   return (
-    <div className="tr">
+    <div className="tr" ref={(element) => onLoadRef?.(element)}>
       <div className="td">
         <div>
           <div className="flex text-sm text-primary-light text-ellipsis">
@@ -43,12 +45,12 @@ export function HistoryItem(props: HistoryItemProps) {
           <div className="flex items-center gap-2 mt-[4px]">
             <div className="flex items-center gap-1">
               <SkeletonElement isLoading={isLoading} width={40}>
-                <h6>{token.name}</h6>
+                <h6>{token && token.name}</h6>
               </SkeletonElement>
             </div>
             <div className="flex items-center gap-1 pl-2 border-l">
               <SkeletonElement isLoading={isLoading} width={40}>
-                <h6>{market.description}</h6>
+                <h6>{market && market.description}</h6>
               </SkeletonElement>
             </div>
             <SkeletonElement isLoading={isLoading} width={40}>

--- a/src/stories/molecule/HistoryItem/stories.ts
+++ b/src/stories/molecule/HistoryItem/stories.ts
@@ -22,11 +22,6 @@ export const Default: Story = {
         address: '0x8888888888888888888888888888888888888888',
         tokenAddress: '0x8888888888888888888888888888888888888888',
         description: 'ETH/USD',
-        oracleValue: {
-          price: 10000n,
-          timestamp: 1000000n,
-          version: 10n,
-        },
       },
       positionId: 1n,
       direction: 'long',

--- a/src/stories/molecule/PositionItemV2/hooks.tsx
+++ b/src/stories/molecule/PositionItemV2/hooks.tsx
@@ -109,7 +109,7 @@ export function usePositionItemV2({ position }: UsePositionItemV2) {
         lossPrice: '-',
         profitPrice: '-',
         entryPrice: '-',
-        entryTime: '-',
+        entryTime: formatTimestamp(position.openTimestamp),
         pnlAmount: '-',
       };
     }

--- a/src/stories/molecule/TradesItem/index.tsx
+++ b/src/stories/molecule/TradesItem/index.tsx
@@ -4,18 +4,20 @@ import { Tag } from '~/stories/atom/Tag';
 import { TradeEntryOnly } from '~/typings/position';
 
 export interface TradesItemProps {
-  trade: TradeEntryOnly;
+  trade?: TradeEntryOnly;
   isLoading: boolean;
+  onLoadRef?: (element: HTMLDivElement | null) => unknown;
 }
 
 export function TradesItem(props: TradesItemProps) {
   const {
-    trade: { token, market, direction, entryPrice, entryTime, collateral, qty, leverage },
+    trade: { token, market, direction, entryPrice, entryTime, collateral, qty, leverage } = {},
     isLoading,
+    onLoadRef,
   } = props;
 
   return (
-    <div className="tr">
+    <div className="tr" ref={(element) => onLoadRef?.(element)}>
       <div className="td">
         <div>
           <div className="flex text-sm text-primary-light">
@@ -26,12 +28,12 @@ export function TradesItem(props: TradesItemProps) {
           <div className="flex items-center gap-2 mt-[2px]">
             <div className="flex items-center gap-1">
               <SkeletonElement isLoading={isLoading} width={40}>
-                <h6>{token.name}</h6>
+                <h6>{token && token.name}</h6>
               </SkeletonElement>
             </div>
             <div className="flex items-center gap-1 pl-2 border-l">
               <SkeletonElement isLoading={isLoading} width={40}>
-                <h6>{market.description}</h6>
+                <h6>{market && market.description}</h6>
               </SkeletonElement>
             </div>
             <SkeletonElement isLoading={isLoading} width={40}>

--- a/src/stories/molecule/TradesItem/stories.ts
+++ b/src/stories/molecule/TradesItem/stories.ts
@@ -22,11 +22,6 @@ export const Default: Story = {
         address: '0x8888888888888888888888888888888888888888',
         tokenAddress: '0x8888888888888888888888888888888888888888',
         description: 'ETH/USD',
-        oracleValue: {
-          price: 10000n,
-          timestamp: 1000000n,
-          version: 10n,
-        },
       },
       positionId: 1n,
       direction: 'long',

--- a/src/stories/template/TradeManagement/index.tsx
+++ b/src/stories/template/TradeManagement/index.tsx
@@ -33,6 +33,8 @@ export const TradeManagement = () => {
     isHistoryLoading,
     historyList,
     tradeList,
+    onFetchNextTrade,
+    onFetchNextHistory,
   } = useTradeManagement();
 
   // TODO: PERCENTAGE

--- a/src/stories/template/TradeManagement/index.tsx
+++ b/src/stories/template/TradeManagement/index.tsx
@@ -32,11 +32,11 @@ export const TradeManagement = () => {
     positionList,
     isHistoryLoading,
     historyList,
-    historyBottomRef,
     tradeList,
-    tradeBottomRef,
-    onFetchNextTrade,
-    onFetchNextHistory,
+    hasMoreHistory,
+    hasMoreTrades,
+    onLoadHistoryRef,
+    onLoadTradesRef,
   } = useTradeManagement();
 
   // TODO: PERCENTAGE
@@ -215,7 +215,13 @@ export const TradeManagement = () => {
                               isLoading={isHistoryLoading}
                             />
                           ))}
-                          <div className="h-[32px] w-full" ref={historyBottomRef} />
+                          {hasMoreHistory && (
+                            <HistoryItem
+                              key={'history-next'}
+                              isLoading={true}
+                              onLoadRef={onLoadHistoryRef}
+                            />
+                          )}
                         </div>
                       </div>
                     )}
@@ -243,7 +249,13 @@ export const TradeManagement = () => {
                               isLoading={isHistoryLoading}
                             />
                           ))}
-                          <div className="h-[32px] w-full" ref={tradeBottomRef} />
+                          {hasMoreTrades && (
+                            <TradesItem
+                              key="trades-next"
+                              isLoading={true}
+                              onLoadRef={onLoadTradesRef}
+                            />
+                          )}
                         </div>
                       </div>
                     )}

--- a/src/stories/template/TradeManagement/index.tsx
+++ b/src/stories/template/TradeManagement/index.tsx
@@ -32,7 +32,9 @@ export const TradeManagement = () => {
     positionList,
     isHistoryLoading,
     historyList,
+    historyBottomRef,
     tradeList,
+    tradeBottomRef,
     onFetchNextTrade,
     onFetchNextHistory,
   } = useTradeManagement();
@@ -213,6 +215,7 @@ export const TradeManagement = () => {
                               isLoading={isHistoryLoading}
                             />
                           ))}
+                          <div className="h-[32px] w-full" ref={historyBottomRef} />
                         </div>
                       </div>
                     )}
@@ -240,6 +243,7 @@ export const TradeManagement = () => {
                               isLoading={isHistoryLoading}
                             />
                           ))}
+                          <div className="h-[32px] w-full" ref={tradeBottomRef} />
                         </div>
                       </div>
                     )}

--- a/src/typings/market.ts
+++ b/src/typings/market.ts
@@ -27,6 +27,8 @@ export interface Market {
   tokenAddress: Address;
 }
 
+export type MarketLike = Omit<Market, 'oracleValue'>;
+
 export interface Bookmark {
   tokenName: string;
   marketDescription: string;

--- a/src/typings/position.ts
+++ b/src/typings/position.ts
@@ -1,6 +1,6 @@
 import { IPosition as IChromaticPosition } from '@chromatic-protocol/sdk-viem';
 import { Address } from 'wagmi';
-import { Market, Token } from './market';
+import { MarketLike, Token } from './market';
 
 export const enum POSITION_STATUS {
   'OPENING',
@@ -60,7 +60,7 @@ export interface ResponseLog {
 
 export interface TradeHistory {
   token: Token;
-  market: Market;
+  market: MarketLike;
   positionId: bigint;
   direction: 'short' | 'long';
   collateral: string;
@@ -76,7 +76,7 @@ export interface TradeHistory {
 
 export interface TradeEntryOnly {
   token: Token;
-  market: Market;
+  market: MarketLike;
   positionId: bigint;
   direction: 'short' | 'long';
   collateral: string;

--- a/src/typings/position.ts
+++ b/src/typings/position.ts
@@ -44,6 +44,20 @@ export interface Position extends IChromaticPosition {
   pnl: bigint;
 }
 
+export interface ResponseLog {
+  address: `0x${string}`;
+  topics: [`0x${string}`, `0x${string}`, `0x${string}`];
+  data: `0x${string}`;
+  blockNumber: `0x${string}`;
+  blockHash: `0x${string}`;
+  timeStamp: `0x${string}`;
+  gasPrice: `0x${string}`;
+  gasUsed: `0x${string}`;
+  logIndex: `0x${string}`;
+  transactionHash: `0x${string}`;
+  transactionIndex: `0x${string}`;
+}
+
 export interface TradeHistory {
   token: Token;
   market: Market;

--- a/src/utils/market.ts
+++ b/src/utils/market.ts
@@ -1,0 +1,13 @@
+import { isNil, isNotNil } from 'ramda';
+import { Market, MarketLike } from '~/typings/market';
+
+export const trimMarket = (market?: Market): MarketLike | undefined => {
+  if (isNil(market)) {
+    return;
+  }
+  const { address, tokenAddress, description } = market;
+  return { address, tokenAddress, description };
+};
+export const trimMarkets = (markets: Market[] = []): MarketLike[] => {
+  return markets.map(trimMarket).filter((market): market is MarketLike => isNotNil(market));
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
 interface ImportMetaEnv {
   readonly VITE_TARGET_CHAIN: 'anvil' | 'arbitrum_goerli' | 'arbitrum_one';
+  readonly VITE_ARBISCAN_KEY: string;
 }


### PR DESCRIPTION
## Description

- Add pagination to components showing logs
  - `Trade`
  - `History`
  
- Get more logs by calling following functions
  - `onFetchNextHistory` for history
  - `onFetchNextTrade` for trade logs

- Arbiscan configs
  - Use Arbiscan api to fetch event logs

- Prevent total margin to be undefined when not connected.

## Related Issues

fixes #509 