### PR TITLE
feat: Show tags of each LPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@chromatic-protocol/liquidity-provider-sdk": "^1.0.1-rc.27",
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
-    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.159",
+    "@chromatic-protocol/sdk-viem": "^0.1.0-rc.160",
     "@floating-ui/dom": "^1.4.2",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@chromatic-protocol/sdk-viem/viem": "1.12.1"
   },
   "dependencies": {
-    "@chromatic-protocol/liquidity-provider-sdk": "^1.0.1-rc.25",
+    "@chromatic-protocol/liquidity-provider-sdk": "^1.0.1-rc.27",
     "@chromatic-protocol/react-compound-charts": "^1.0.0-rc.9",
     "@chromatic-protocol/sdk-viem": "^0.1.0-rc.159",
     "@floating-ui/dom": "^1.4.2",

--- a/src/configs/lp.ts
+++ b/src/configs/lp.ts
@@ -1,2 +1,8 @@
 export const SUBGRAPH_API_URL =
   'https://graph-arbitrum-goerli.api.chromatic.finance/subgraphs/name/chromatic-lp';
+
+export const LP_TAG_ORDER: Record<string, number> = {
+  'Low Risk': 0,
+  'Mid Risk': 1,
+  'High Risk': 2,
+};

--- a/src/configs/token.ts
+++ b/src/configs/token.ts
@@ -22,7 +22,6 @@ const arbitrumGoerliFeeds: Record<string, Address | undefined> = {
   USDT: '0x0a023a3423D9b27A0BE48c768CCF2dD7877fEf5E',
   LINK: '0xd28Ba6CA3bB72bF371b80a2a0a33cBcf9073C954',
   DAI: '0x103b53E977DA6E4Fa92f76369c8b7e20E7fb7fe1',
-  CHRM: '0x1692Bdd32F31b831caAc1b0c9fAF68613682813b',
 };
 export const PRICE_FEEDS: Record<string, Record<string, Address | undefined> | undefined> = {
   arbitrum_one: arbitrumFeeds,

--- a/src/configs/wagmiClient.ts
+++ b/src/configs/wagmiClient.ts
@@ -11,5 +11,7 @@ export const { chains, publicClient, webSocketPublicClient } = configureChains(
         batchSize: 2048,
       },
     },
+    pollingInterval: 1000 * 12,
+    retryCount: 1,
   }
 );

--- a/src/hooks/useChromaticAccount.ts
+++ b/src/hooks/useChromaticAccount.ts
@@ -1,7 +1,7 @@
 import { fromPairs, isNil } from 'ramda';
-import { Address } from 'wagmi';
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import { Address } from 'wagmi';
 import { useAppDispatch, useAppSelector } from '~/store';
 import { accountAction } from '~/store/reducer/account';
 import { ACCOUNT_STATUS } from '~/typings/account';
@@ -19,7 +19,7 @@ export const useChromaticAccount = () => {
   const status = useAppSelector((state) => state.account.status);
   const { setAccountStatus } = accountAction;
 
-  const { client, walletAddress } = useChromaticClient();
+  const { client, walletAddress, isReady } = useChromaticClient();
 
   const fetchKey = useMemo(
     () => ({
@@ -35,7 +35,7 @@ export const useChromaticAccount = () => {
     error,
     mutate: fetchAddress,
     isLoading: isAccountAddressLoading,
-  } = useSWR(checkAllProps(fetchKey) && fetchKey, async () => {
+  } = useSWR(isReady && checkAllProps(fetchKey) && fetchKey, async ({ address }) => {
     try {
       const accountApi = client.account();
       const accountAddress = await accountApi.getAccount();

--- a/src/hooks/useChromaticLp.ts
+++ b/src/hooks/useChromaticLp.ts
@@ -30,6 +30,7 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
   const lpAddresses = await registry?.lpListByMarket(market.address);
   const lpInfoArray = lpAddresses.map(async (lpAddress) => {
     const lp = lpClient.lp();
+    const lpTag = lp.getLpTag(lpAddress);
     const lpName = lp.getLpName(lpAddress);
     let balance = undefined as Promise<bigint> | undefined;
     if (isNotNil(walletAddress)) {
@@ -49,6 +50,7 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
       totalSupply,
       valueInfo,
       utilization,
+      lpTag,
     ] as const;
     const response = await Promise.allSettled(requests);
     return response.reduce(
@@ -97,6 +99,13 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
             provider = {
               ...provider,
               utilization: value as number,
+            };
+            break;
+          }
+          case 7: {
+            provider = {
+              ...provider,
+              tag: value as Awaited<typeof lpTag>,
             };
             break;
           }

--- a/src/hooks/useChromaticLp.ts
+++ b/src/hooks/useChromaticLp.ts
@@ -4,6 +4,7 @@ import { isNil, isNotNil } from 'ramda';
 import { toast } from 'react-toastify';
 import useSWR from 'swr';
 import { Address, useAccount } from 'wagmi';
+import { LP_TAG_ORDER } from '~/configs/lp';
 import { useAppDispatch } from '~/store';
 import { lpAction } from '~/store/reducer/lp';
 import { ChromaticLp } from '~/typings/lp';
@@ -36,8 +37,7 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
     if (isNotNil(walletAddress)) {
       balance = lp.balanceOf(lpAddress, walletAddress);
     }
-    const metadata = await lp.lpTokenMeta(lpAddress);
-    const { decimals, symbol: clpName } = metadata;
+    const metadata = lp.lpTokenMeta(lpAddress);
     const totalSupply = lp.totalSupply(lpAddress);
     const valueInfo = lp.valueInfo(lpAddress);
     const utilization = lp.utilization(lpAddress);
@@ -46,7 +46,7 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
       lpAddress,
       lpName,
       balance,
-      decimals,
+      metadata,
       totalSupply,
       valueInfo,
       utilization,
@@ -73,6 +73,7 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
             break;
           }
           case 3: {
+            const { decimals, symbol: clpName } = value as Awaited<typeof metadata>;
             provider.decimals = decimals;
             provider.clpName = clpName;
             break;
@@ -122,7 +123,14 @@ const fetchChromaticLp = async (args: FetchChromaticLpArgs) => {
     );
   });
 
-  return PromiseOnlySuccess(lpInfoArray) ?? [];
+  const settledLpArray = (await PromiseOnlySuccess(lpInfoArray)) ?? [];
+  settledLpArray.sort((previousLp, nextLp) => {
+    const { tag: previousLpTag } = previousLp;
+    const { tag: nextLpTag } = nextLp;
+    return LP_TAG_ORDER[previousLpTag] - LP_TAG_ORDER[nextLpTag];
+  });
+
+  return settledLpArray;
 };
 
 export const useEntireChromaticLp = () => {
@@ -152,7 +160,6 @@ export const useEntireChromaticLp = () => {
         const lpArray = await fetchChromaticLp({ lpClient, registry, walletAddress, market });
         chromaticLps = chromaticLps.concat(lpArray);
       }
-
       return chromaticLps.map((lpValue) => {
         const { totalValue, totalSupply, decimals, market } = lpValue;
         const settlementToken = tokens?.find((token) => token.address === market.tokenAddress);

--- a/src/hooks/useLpReceiptCount.ts
+++ b/src/hooks/useLpReceiptCount.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 import { useAccount } from 'wagmi';
 import { getSdk } from '~/__generated__/request';
@@ -64,15 +64,20 @@ export const useLpReceiptCount = () => {
       };
     },
     {
-      refreshInterval: 1000 * 20,
+      refreshInterval: 0,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+      revalidateOnFocus: false,
+      revalidateFirstPage: true,
+      shouldRetryOnError: false,
     }
   );
 
   useError({ error });
 
-  const onRefreshLpReceiptCount = () => {
+  const onRefreshLpReceiptCount = useCallback(() => {
     mutate();
-  };
+  }, [mutate]);
 
   return {
     count,

--- a/src/hooks/useLpReceiptEvent.ts
+++ b/src/hooks/useLpReceiptEvent.ts
@@ -1,0 +1,77 @@
+import { iChromaticLpABI } from '@chromatic-protocol/liquidity-provider-sdk/contracts';
+import { isNil, isNotNil } from 'ramda';
+import { useEffect, useMemo, useRef } from 'react';
+import { useAccount } from 'wagmi';
+import { dispatchLpReceiptEvent } from '~/typings/events';
+import { useChromaticClient } from './useChromaticClient';
+import { useChromaticLp } from './useChromaticLp';
+
+const receiptAbi = iChromaticLpABI
+  .map((abi) => {
+    const { type, name } = abi;
+    if (type !== 'event') {
+      return null;
+    }
+    switch (name) {
+      case 'AddLiquidity':
+      case 'AddLiquiditySettled':
+      case 'RemoveLiquidity':
+      case 'RemoveLiquiditySettled': {
+        return abi;
+      }
+      default: {
+        return null;
+      }
+    }
+  })
+  .filter((abi): abi is NonNullable<Exclude<typeof abi, null>> => isNotNil(abi));
+
+export const useLpReceiptEvent = () => {
+  const { lpClient, isReady } = useChromaticClient();
+  const { lpList } = useChromaticLp();
+  const { address } = useAccount();
+  const ref = useRef<((() => unknown) | undefined)[]>([]);
+
+  const lpAddresses = useMemo(() => {
+    if (isNil(lpList)) {
+      return [];
+    }
+    return lpList?.map((lp) => lp.address);
+  }, [lpList]);
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+    if (lpAddresses.length === 0) {
+      return;
+    }
+    if (ref.current.length > 0) {
+      return;
+    }
+    for (let index = 0; index < lpAddresses.length; index++) {
+      const lpAddress = lpAddresses[index];
+      const unwatch = lpClient.publicClient?.watchEvent({
+        address: lpAddress,
+        events: receiptAbi,
+        onLogs: (logs) => {
+          const filteredLogs = logs.filter(
+            (log) => isNotNil(log) && 'recipient' in log.args && log.args.recipient === address
+          );
+          if (filteredLogs.length > 0) {
+            dispatchLpReceiptEvent();
+          }
+        },
+      });
+      ref.current.push(unwatch);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady, lpAddresses, address]);
+
+  useEffect(() => {
+    return () => {
+      ref.current.forEach((f) => f?.());
+    };
+  }, []);
+};

--- a/src/hooks/useLpReceipts.ts
+++ b/src/hooks/useLpReceipts.ts
@@ -184,7 +184,7 @@ const mapToDetailedReceipts = async (args: MapToDetailedReceiptsArgs) => {
       detail = formatDecimals(receipt.burnedAmount, token.decimals, 2, true) + ' ' + token.name;
     }
     let message = status === 'standby' ? 'Waiting for the next oracle round' : 'Completed';
-    const key = `${currentAction}-receipt-${receipt.id}-${receipt.action}-${status}`;
+    const key = `${token.name}-${currentAction}-receipt-${receipt.id}-${receipt.action}-${status}`;
 
     if (receipt.action === 'burning' && receipt.remainedAmount > 0n) {
       const dividedByAmount = divPreserved(

--- a/src/hooks/useLpReceipts.ts
+++ b/src/hooks/useLpReceipts.ts
@@ -6,6 +6,7 @@
 import { Client } from '@chromatic-protocol/sdk-viem';
 import { GraphQLClient } from 'graphql-request';
 import { isNil, isNotNil } from 'ramda';
+import { useCallback } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { Address, useAccount } from 'wagmi';
 import {
@@ -341,7 +342,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
       return receiptsData;
     },
     {
-      refreshInterval: 1000 * 20,
+      refreshInterval: 0,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
       revalidateOnFocus: false,
@@ -352,16 +353,16 @@ export const useLpReceipts = (props: UseLpReceipts) => {
 
   useError({ error });
 
-  const onFetchNextLpReceipts = () => {
+  const onFetchNextLpReceipts = useCallback(() => {
     if (isLoading) {
       return;
     }
     setSize(size + 1);
-  };
+  }, [isLoading, size, setSize]);
 
-  const onRefreshLpReceipts = () => {
+  const onRefreshLpReceipts = useCallback(() => {
     mutate();
-  };
+  }, [mutate]);
 
   return {
     receiptsData,

--- a/src/pages/faucet/index.tsx
+++ b/src/pages/faucet/index.tsx
@@ -1,5 +1,6 @@
 import { testSettlementTokenABI } from '@chromatic-protocol/sdk-viem';
 import { isNil } from 'ramda';
+import { toast } from 'react-toastify';
 import { getContract } from 'viem';
 import { useAccount } from 'wagmi';
 import { arbitrumGoerli } from 'wagmi/chains';
@@ -17,26 +18,36 @@ export const Faucet = () => {
   const { client } = useChromaticClient();
   const { onLoadBackgroundRef } = useBackgroundGradient();
   const onFaucet = async () => {
-    if (isNil(client.walletClient)) {
-      return;
-    }
-    const cTST = tokens?.find((token) => token.name === 'cTST');
-    if (isNil(tokens) || isNil(cTST)) {
-      return;
-    }
-    if (isNil(address)) {
-      return;
-    }
-    const contract = getContract({
-      abi: testSettlementTokenABI,
-      address: cTST!.address,
-      publicClient: client.publicClient,
-      walletClient: client.walletClient,
-    });
-    const { request } = await contract.simulate.faucet({ account: address, chain: arbitrumGoerli });
+    try {
+      if (isNil(client.walletClient)) {
+        return;
+      }
+      const cTST = tokens?.find((token) => token.name === 'cETH');
+      if (isNil(tokens) || isNil(cTST)) {
+        return;
+      }
+      if (isNil(address)) {
+        return;
+      }
+      const contract = getContract({
+        abi: testSettlementTokenABI,
+        address: cTST!.address,
+        publicClient: client.publicClient,
+        walletClient: client.walletClient,
+      });
+      const { request } = await contract.simulate.faucet({
+        account: address,
+        chain: arbitrumGoerli,
+      });
 
-    const hash = await client.walletClient?.writeContract(request);
-    await client.publicClient?.waitForTransactionReceipt({ hash });
+      const hash = await client.walletClient?.writeContract(request);
+      await client.publicClient?.waitForTransactionReceipt({ hash });
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error(error);
+      }
+      toast.error('Invalid faucet');
+    }
   };
 
   return (

--- a/src/pages/poolV3/index.tsx
+++ b/src/pages/poolV3/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import PlusIcon from '~/assets/icons/PlusIcon';
 import useBackgroundGradient from '~/hooks/useBackgroundGradient';
 import { useLpLocal } from '~/hooks/useLpLocal';
+import { useLpReceiptEvent } from '~/hooks/useLpReceiptEvent';
 import { useMarketLocal } from '~/hooks/useMarketLocal';
 import { useTokenLocal } from '~/hooks/useTokenLocal';
 import { useAppSelector } from '~/store';
@@ -30,6 +31,7 @@ const PoolV3 = () => {
   useTokenLocal();
   useMarketLocal();
   useLpLocal();
+  useLpReceiptEvent();
   const { onLoadBackgroundRef } = useBackgroundGradient();
 
   const selectedLp = useAppSelector((state) => state.lp.selectedLp);

--- a/src/pages/poolV3/index.tsx
+++ b/src/pages/poolV3/index.tsx
@@ -1,5 +1,6 @@
-import { isNil, isNotNil } from 'ramda';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { isNil, isNotNil } from 'ramda';
+import { useMemo } from 'react';
 import PlusIcon from '~/assets/icons/PlusIcon';
 import useBackgroundGradient from '~/hooks/useBackgroundGradient';
 import { useLpLocal } from '~/hooks/useLpLocal';
@@ -37,6 +38,20 @@ const PoolV3 = () => {
     : undefined;
   const price = formatDecimals(selectedLp?.price, selectedLp?.decimals, 3, true);
   const marketDescription = selectedLp?.market.description;
+  const tagClass = useMemo(() => {
+    switch (selectedLp?.tag.toLowerCase()) {
+      case 'high risk': {
+        return 'tag-risk-high';
+      }
+      case 'mid risk': {
+        return 'tag-risk-mid';
+      }
+      case 'low risk': {
+        return 'tag-risk-low';
+      }
+    }
+    return '';
+  }, [selectedLp]);
 
   return (
     <>
@@ -59,10 +74,10 @@ const PoolV3 = () => {
                 <div className="flex items-center mb-5">
                   <SkeletonElement isLoading={isNil(lpTitle)} width={120} containerClassName="mr-3">
                     <h2 className="mr-3 text-4xl">
-                      {lpTitle} {selectedLp?.name} Pool
+                      {lpTitle} {selectedLp?.name}
                     </h2>
                   </SkeletonElement>
-                  <Tag label={`high risk`} className="tag-risk-high" />
+                  <Tag label={selectedLp?.tag} className={tagClass} />
                   <Button
                     label="Metamask"
                     iconLeft={<PlusIcon className="w-3 h-3" />}

--- a/src/stories/molecule/AccountPanelV3/hooks.tsx
+++ b/src/stories/molecule/AccountPanelV3/hooks.tsx
@@ -6,7 +6,6 @@ import { usePublicClient } from 'wagmi';
 import { useChromaticAccount } from '~/hooks/useChromaticAccount';
 import { useCreateAccount } from '~/hooks/useCreateAccount';
 import { useMargins } from '~/hooks/useMargins';
-import usePriceFeed from '~/hooks/usePriceFeed';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
 import { useTokenBalances } from '~/hooks/useTokenBalance';
 import useTokenTransaction from '~/hooks/useTokenTransaction';
@@ -35,7 +34,6 @@ export const useAccountPanelV3 = ({ type }: UseAccountPanelV3Props) => {
   const { totalMargin } = useMargins();
   const { totalBalance } = useMargins();
   const { currentToken, isTokenLoading } = useSettlementToken();
-  const { isFeedLoading } = usePriceFeed();
 
   const publicClient = usePublicClient();
 
@@ -65,7 +63,7 @@ export const useAccountPanelV3 = ({ type }: UseAccountPanelV3Props) => {
     }
   }, [publicClient, chromaticAddress]);
 
-  const isLoading = isTokenLoading || isFeedLoading || isAccountAddressLoading;
+  const isLoading = isTokenLoading || isAccountAddressLoading;
 
   const isDeposit = type === 'Deposit';
 

--- a/src/stories/molecule/AmountSwitch/index.tsx
+++ b/src/stories/molecule/AmountSwitch/index.tsx
@@ -14,6 +14,7 @@ interface AmountSwitchProps {
   tokenName?: string;
   tokenImage?: string;
   minAmount: string;
+  maxAmount: string | number;
   optionInputDirection?: 'row' | 'column';
   onAmountChange: (value: string) => unknown;
 }
@@ -30,6 +31,7 @@ export const AmountSwitch = (props: AmountSwitchProps) => {
     tokenImage,
     onAmountChange,
     minAmount,
+    maxAmount,
     optionInputDirection,
   } = props;
 
@@ -64,6 +66,7 @@ export const AmountSwitch = (props: AmountSwitchProps) => {
         <div className={`tooltip-input-balance-${direction}`}>
           <OptionInput
             value={preset.value.toString()}
+            maxValue={maxAmount}
             onChange={onAmountChange}
             placeholder="0"
             error={disabled && !!errorMessage}

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -4,7 +4,7 @@ import { useLastOracle } from '~/hooks/useLastOracle';
 import useLocalStorage from '~/hooks/useLocalStorage';
 import { useLpReceiptCount } from '~/hooks/useLpReceiptCount';
 import { useLpReceipts } from '~/hooks/useLpReceipts';
-import { LP_EVENT } from '~/typings/events';
+import { LP_EVENT, LP_RECEIPT_EVENT } from '~/typings/events';
 import { LpReceipt } from '~/typings/lp';
 
 export const usePoolProgressV2 = () => {
@@ -82,6 +82,17 @@ export const usePoolProgressV2 = () => {
       window.removeEventListener(LP_EVENT, onLp);
     };
   }, [setIsGuideOpen]);
+
+  useEffect(() => {
+    function onLpReceiptRefresh() {
+      onRefreshLpReceipts();
+      onRefreshLpReceiptCount();
+    }
+    window.addEventListener(LP_RECEIPT_EVENT, onLpReceiptRefresh);
+    return () => {
+      window.removeEventListener(LP_RECEIPT_EVENT, onLpReceiptRefresh);
+    };
+  }, [onRefreshLpReceipts, onRefreshLpReceiptCount]);
 
   return {
     openButtonRef,

--- a/src/stories/molecule/TradeContent/hooks.tsx
+++ b/src/stories/molecule/TradeContent/hooks.tsx
@@ -56,7 +56,7 @@ export function useTradeContent(props: TradeContentProps) {
     balances && tokenAddress && balances[tokenAddress]
       ? numberFormat(formatUnits(balances[tokenAddress], tokenDecimals), {
           maxDigits: 5,
-          useGrouping: true,
+          useGrouping: false,
         })
       : 0;
 

--- a/src/stories/molecule/TradeContent/index.tsx
+++ b/src/stories/molecule/TradeContent/index.tsx
@@ -2,12 +2,12 @@ import '~/stories/atom/Select/style.css';
 import '~/stories/atom/Toggle/style.css';
 
 import { Listbox, Switch } from '@headlessui/react';
-import { TradeChart } from '~/stories/atom/TradeChart';
 import { Input } from '~/stories/atom/Input';
 import { LeverageOption } from '~/stories/atom/LeverageOption';
 import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Slider } from '~/stories/atom/Slider';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
+import { TradeChart } from '~/stories/atom/TradeChart';
 import { AmountSwitch } from '~/stories/molecule/AmountSwitch';
 import { TransactionButton } from '~/stories/molecule/TransactionButton';
 
@@ -113,6 +113,7 @@ export const TradeContent = (props: TradeContentProps) => {
               disableDetail={disableDetail}
               tokenName={tokenName}
               minAmount={minAmount}
+              maxAmount={balance}
               onAmountChange={onAmountChange}
             />
           </div>

--- a/src/stories/molecule/TradeContentV2/hooks.tsx
+++ b/src/stories/molecule/TradeContentV2/hooks.tsx
@@ -56,7 +56,7 @@ export function useTradeContentV2(props: TradeContentV2Props) {
     balances && tokenAddress && balances[tokenAddress]
       ? numberFormat(formatUnits(balances[tokenAddress], tokenDecimals), {
           maxDigits: 5,
-          useGrouping: true,
+          useGrouping: false,
         })
       : 0;
 

--- a/src/stories/molecule/TradeContentV2/index.tsx
+++ b/src/stories/molecule/TradeContentV2/index.tsx
@@ -8,9 +8,9 @@ import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Slider } from '~/stories/atom/Slider';
 import { Tag } from '~/stories/atom/Tag';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
+import { TradeChart } from '~/stories/atom/TradeChart';
 import { AmountSwitch } from '~/stories/molecule/AmountSwitch';
 import { TransactionButton } from '~/stories/molecule/TransactionButton';
-import { TradeChart } from '~/stories/atom/TradeChart';
 
 import { useTradeContentV2 } from './hooks';
 
@@ -117,6 +117,7 @@ export const TradeContentV2 = (props: TradeContentV2Props) => {
               disableDetail={disableDetail}
               tokenName={tokenName}
               minAmount={minAmount}
+              maxAmount={balance}
               onAmountChange={onAmountChange}
             />
           </div>

--- a/src/stories/molecule/TradeContentV3/hooks.tsx
+++ b/src/stories/molecule/TradeContentV3/hooks.tsx
@@ -57,7 +57,7 @@ export function useTradeContentV3(props: TradeContentV3Props) {
     balances && tokenAddress && balances[tokenAddress]
       ? numberFormat(formatUnits(balances[tokenAddress], tokenDecimals), {
           maxDigits: 5,
-          useGrouping: true,
+          useGrouping: false,
         })
       : 0;
 
@@ -93,7 +93,7 @@ export function useTradeContentV3(props: TradeContentV3Props) {
   const minTakeProfit = oracleProperties?.minTakeProfit || 1;
   const maxTakeProfit = useMemo(
     () => (isLong ? oracleProperties?.maxTakeProfit || 1000 : 100),
-    [direction]
+    [isLong, oracleProperties?.maxTakeProfit]
   );
   const takeProfitPlaceholder = '10';
 
@@ -114,7 +114,7 @@ export function useTradeContentV3(props: TradeContentV3Props) {
         ? '-'
         : numberFormat(value, { useGrouping: true, compact: true, type: 'string' });
     return [format(freeLiq), format(totalLiq)];
-  }, [totalUnusedLiquidity, totalMaxLiquidity, currentToken]);
+  }, [totalUnusedLiquidity, totalMaxLiquidity, tokenDecimals]);
 
   const tradeFee = formatDecimals(fee, tokenDecimals, 2);
   const tradeFeePercent = formatDecimals(feePercent, tokenDecimals, 3);
@@ -169,7 +169,7 @@ export function useTradeContentV3(props: TradeContentV3Props) {
       stopLossRatio: `${isLong ? '-' : '+'}${format(stopLoss)}`,
       stopLossPrice: format(stopLossPrice),
     };
-  }, [input, currentMarket]);
+  }, [input, currentMarket, direction]);
 
   return {
     disabled,

--- a/src/stories/molecule/TradeContentV3/index.tsx
+++ b/src/stories/molecule/TradeContentV3/index.tsx
@@ -4,13 +4,12 @@ import '~/stories/atom/Toggle/style.css';
 import { Listbox, Switch } from '@headlessui/react';
 import { Input } from '~/stories/atom/Input';
 import { LeverageOption } from '~/stories/atom/LeverageOption';
-import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Slider } from '~/stories/atom/Slider';
 import { Tag } from '~/stories/atom/Tag';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
+import { TradeChart } from '~/stories/atom/TradeChart';
 import { AmountSwitch } from '~/stories/molecule/AmountSwitch';
 import { TransactionButton } from '~/stories/molecule/TransactionButton';
-import { TradeChart } from '~/stories/atom/TradeChart';
 
 import { useTradeContentV3 } from './hooks';
 
@@ -118,6 +117,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
             tokenName={tokenName}
             tokenImage={tokenImage}
             minAmount={minAmount}
+            maxAmount={balance}
             onAmountChange={onAmountChange}
             optionInputDirection="row"
           />

--- a/src/stories/molecule/WalletPopoverV3/index.tsx
+++ b/src/stories/molecule/WalletPopoverV3/index.tsx
@@ -148,49 +148,48 @@ export function WalletPopoverV3({ isDisconnected, isWrongChain }: WalletPopoverV
                                 <p className="text-center text-primary/20">You have no asset.</p>
                               ) : (
                                 <div className="flex flex-col gap-3">
-                                  {assets.map(
-                                    ({ key, name, image, usdPrice, balance, explorerUrl }) => (
-                                      <div key={key} className="flex items-center">
-                                        <div className="flex items-center gap-1">
-                                          <SkeletonElement
-                                            isLoading={isLoading}
-                                            circle
-                                            width={24}
-                                            height={24}
+                                  {assets.map(({ key, name, image, balance, explorerUrl }) => (
+                                    <div key={key} className="flex items-center">
+                                      <div className="flex items-center gap-1">
+                                        <SkeletonElement
+                                          isLoading={isLoading}
+                                          circle
+                                          width={24}
+                                          height={24}
+                                        />
+                                        <SkeletonElement isLoading={isLoading} width={40}>
+                                          <Avatar
+                                            label={name}
+                                            src={image}
+                                            size="base"
+                                            fontSize="base"
+                                            gap="2"
                                           />
-                                          <SkeletonElement isLoading={isLoading} width={40}>
-                                            <Avatar
-                                              label={name}
-                                              src={image}
-                                              size="base"
-                                              fontSize="base"
-                                              gap="2"
-                                            />
-                                          </SkeletonElement>
-                                          <Button
-                                            href={explorerUrl}
-                                            iconOnly={<OutlinkIcon />}
-                                            css="unstyled"
-                                            size="sm"
-                                            className="text-primary-light"
-                                          />
-                                        </div>
+                                        </SkeletonElement>
+                                        <Button
+                                          href={explorerUrl}
+                                          iconOnly={<OutlinkIcon />}
+                                          css="unstyled"
+                                          size="sm"
+                                          className="text-primary-light"
+                                        />
+                                      </div>
 
-                                        <div className="ml-auto text-right">
-                                          <p className="text-sm text-primary-lighter">
+                                      <div className="ml-auto text-right">
+                                        {/* TODO: Don't show prices of each token in USD */}
+                                        {/* <p className="text-sm text-primary-lighter">
                                             <SkeletonElement isLoading={isLoading} width={40}>
                                               ${usdPrice}
                                             </SkeletonElement>
-                                          </p>
-                                          <p className="mt-1 text-base font-medium text-primary">
-                                            <SkeletonElement isLoading={isLoading} width={40}>
-                                              {balance} {name}
-                                            </SkeletonElement>
-                                          </p>
-                                        </div>
+                                          </p> */}
+                                        <p className="mt-1 text-base font-medium text-primary">
+                                          <SkeletonElement isLoading={isLoading} width={40}>
+                                            {balance} {name}
+                                          </SkeletonElement>
+                                        </p>
                                       </div>
-                                    )
-                                  )}
+                                    </div>
+                                  ))}
                                 </div>
                               )}
                             </article>

--- a/src/stories/molecule/WalletPopoverV3/index.tsx
+++ b/src/stories/molecule/WalletPopoverV3/index.tsx
@@ -235,7 +235,7 @@ export function WalletPopoverV3({ isDisconnected, isWrongChain }: WalletPopoverV
                                               <SkeletonElement isLoading={isLoading} width={100}>
                                                 <p className="text-primary-lighter">
                                                   {/* pool name */}
-                                                  {name} Pool
+                                                  {name}
                                                 </p>
                                               </SkeletonElement>
                                               <SkeletonElement isLoading={isLoading} width={60}>

--- a/src/stories/template/PoolDetail/hooks.ts
+++ b/src/stories/template/PoolDetail/hooks.ts
@@ -12,6 +12,23 @@ export const usePoolDetail = () => {
     }
     return `CLP-${selectedLp.settlementToken.name}-${selectedLp.market.description}`;
   }, [selectedLp]);
+  const lpTag = useMemo(() => {
+    if (isNil(selectedLp)) {
+      return;
+    }
+    switch (selectedLp.tag.toLowerCase()) {
+      case 'high risk': {
+        return 'text-risk-high';
+      }
+      case 'mid risk': {
+        return 'text-risk-mid';
+      }
+      case 'low risk': {
+        return 'text-risk-low';
+      }
+    }
+    return '';
+  }, [selectedLp]);
 
   const onCopyAddress = () => {
     if (selectedLp) {
@@ -24,6 +41,7 @@ export const usePoolDetail = () => {
   return {
     lpTitle,
     lpName: selectedLp?.name,
+    lpTag,
     lpAddress: selectedLp?.address,
     // marketDescription: selectedLp?.market.description,
     onCopyAddress,

--- a/src/stories/template/PoolDetail/index.tsx
+++ b/src/stories/template/PoolDetail/index.tsx
@@ -11,7 +11,7 @@ export interface PoolDetailProps {}
 
 export const PoolDetail = (props: PoolDetailProps) => {
   const blockExplorer = useBlockExplorer();
-  const { lpTitle, lpName, lpAddress, onCopyAddress } = usePoolDetail();
+  const { lpTitle, lpName, lpTag, lpAddress, onCopyAddress } = usePoolDetail();
 
   return (
     <div className="p-5 PoolDetail">
@@ -21,7 +21,7 @@ export const PoolDetail = (props: PoolDetailProps) => {
             <h3>{lpTitle}</h3>
           </SkeletonElement>
           {/* todo: change text-color for each risk - high / mid / low */}
-          <h3 className={`text-risk-high`}>{lpName} Pool</h3>
+          <h3 className={lpTag}>{lpName}</h3>
         </div>
         <div className="flex gap-2">
           <AddressCopyButton

--- a/src/stories/template/PoolMenuV3/hooks.ts
+++ b/src/stories/template/PoolMenuV3/hooks.ts
@@ -25,6 +25,7 @@ export const usePoolMenuV3 = () => {
       const assets = formatDecimals(lp.totalValue, lp.settlementToken.decimals, 2, true);
       return {
         name: lp.name,
+        tag: lp.tag,
         price,
         assets,
         label: undefined as string | undefined,

--- a/src/stories/template/PoolMenuV3/hooks.ts
+++ b/src/stories/template/PoolMenuV3/hooks.ts
@@ -1,14 +1,12 @@
 import { isNil } from 'ramda';
 import { useMemo } from 'react';
 import { useChromaticLp } from '~/hooks/useChromaticLp';
-import { useAppDispatch, useAppSelector } from '~/store';
-import { lpAction } from '~/store/reducer/lp';
+import { useAppSelector } from '~/store';
 import { formatDecimals } from '~/utils/number';
 
 export const usePoolMenuV3 = () => {
-  const { lpList } = useChromaticLp();
+  const { lpList, onLpSelect } = useChromaticLp();
   const selectedLp = useAppSelector((state) => state.lp.selectedLp);
-  const dispatch = useAppDispatch();
 
   const onMenuClick = (lpName: string) => {
     const nextLp = lpList?.find((lp) => lp.name === lpName);
@@ -16,7 +14,7 @@ export const usePoolMenuV3 = () => {
     if (isNil(nextLp)) {
       return;
     }
-    dispatch(lpAction.onLpSelect(nextLp));
+    onLpSelect(nextLp);
   };
 
   const formattedLp = useMemo(() => {

--- a/src/stories/template/PoolMenuV3/index.tsx
+++ b/src/stories/template/PoolMenuV3/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import ArrowTriangleIcon from '~/assets/icons/ArrowTriangleIcon';
 import '~/stories/atom/Tabs/style.css';
 import { Tag } from '~/stories/atom/Tag';
@@ -14,10 +15,10 @@ export const PoolMenuV3 = (props: PoolMenuV3Props) => {
         return (
           <PoolMenuV3Item
             key={`${lp.name}-${lpIndex}`}
-            title={lp.name}
+            name={lp.name}
+            tag={lp.tag}
             price={lp.price}
             aum={lp.assets}
-            label={lp.label ?? 'No labels'}
             tokenSymbol={lp.tokenSymbol}
             selected={lp.name === selectedLp?.name}
             onClick={() => {
@@ -31,8 +32,8 @@ export const PoolMenuV3 = (props: PoolMenuV3Props) => {
 };
 
 export interface PoolMenuV3ItemProps {
-  label: string;
-  title: string;
+  name: string;
+  tag: string;
   price: number | string;
   aum: number | string;
   tokenSymbol: string;
@@ -41,19 +42,33 @@ export interface PoolMenuV3ItemProps {
 }
 
 export const PoolMenuV3Item = (props: PoolMenuV3ItemProps) => {
-  const { label, title, price, aum, tokenSymbol, selected, onClick } = props;
+  const { name, tag, price, aum, tokenSymbol, selected, onClick } = props;
+  const tagClass = useMemo(() => {
+    switch (tag.toLowerCase()) {
+      case 'high risk': {
+        return 'tag-risk-high';
+      }
+      case 'mid risk': {
+        return 'tag-risk-mid';
+      }
+      case 'low risk': {
+        return 'tag-risk-low';
+      }
+    }
+    return '';
+  }, [tag]);
 
   return (
     <button
       className={`flex items-center w-full px-5 py-3 border rounded ${
         selected ? 'border-primary-light bg-primary/10' : 'border-primary/10'
       }`}
-      title={title}
+      title={name}
       onClick={onClick}
     >
       <div className="text-left">
-        <Tag label={`${label} risk`} className={`tag-risk-${label}`} />
-        <h3 className="mt-2 mb-3 text-xl">{title}</h3>
+        <Tag label={`${tag}`} className={tagClass} />
+        <h3 className="mt-2 mb-3 text-xl">{name}</h3>
         <div className="flex text-primary-light">
           <p>
             Price

--- a/src/stories/template/PoolStat/hooks.ts
+++ b/src/stories/template/PoolStat/hooks.ts
@@ -8,10 +8,11 @@ export const usePoolStat = () => {
       ' ' +
       selectedLp.settlementToken.name
     : undefined;
-  const clpSupply =
-    formatDecimals(selectedLp?.totalSupply, selectedLp?.decimals, 3, true) +
-    ' ' +
-    selectedLp?.clpName;
+  const clpSupply = selectedLp
+    ? formatDecimals(selectedLp.totalSupply, selectedLp.decimals, 3, true) +
+      ' ' +
+      selectedLp.clpName
+    : undefined;
   const utilization = formatDecimals(selectedLp?.utilization, 2, 2, false) + ' %';
   const utilizedValue = selectedLp
     ? formatDecimals(

--- a/src/stories/template/PoolStat/index.tsx
+++ b/src/stories/template/PoolStat/index.tsx
@@ -42,9 +42,11 @@ export const PoolStat = (props: PoolStatProps) => {
               <TooltipGuide label="clp-supply" tip="The amount of CLP in circulation" outLink="" />
             </div>
           </div>
-          <div className="text-right">
-            <Avatar label={clpSupply} size="sm" fontSize="lg" gap="1" src={clpImage} />
-          </div>
+          <SkeletonElement isLoading={isNil(clpSupply)} width={60}>
+            <div className="text-right">
+              <Avatar label={clpSupply} size="sm" fontSize="lg" gap="1" src={clpImage} />
+            </div>
+          </SkeletonElement>
         </div>
       </div>
       <div className="flex flex-col gap-3 pt-3 mt-5 border-t">

--- a/src/typings/events.ts
+++ b/src/typings/events.ts
@@ -1,6 +1,7 @@
 export const TRADE_EVENT = 'trade';
 export const POOL_EVENT = 'pool';
 export const LP_EVENT = 'lp';
+export const LP_RECEIPT_EVENT = 'lp-receipts';
 
 export const dispatchTradeEvent = () =>
   window.dispatchEvent(
@@ -23,11 +24,20 @@ export const dispatchLpEvent = () =>
       cancelable: true,
     })
   );
+export const dispatchLpReceiptEvent = () => {
+  window.dispatchEvent(
+    new CustomEvent(LP_RECEIPT_EVENT, {
+      bubbles: true,
+      cancelable: true,
+    })
+  );
+};
 declare global {
   interface CustomEventMap {
     [TRADE_EVENT]: CustomEvent<unknown>;
     [POOL_EVENT]: CustomEvent<unknown>;
     [LP_EVENT]: CustomEvent<unknown>;
+    [LP_RECEIPT_EVENT]: CustomEvent<unknown>;
   }
   interface Window {
     addEventListener<K extends keyof CustomEventMap>(

--- a/src/typings/lp.ts
+++ b/src/typings/lp.ts
@@ -4,6 +4,7 @@ import { Market, Token } from './market';
 export interface ChromaticLp {
   address: Address;
   name: string;
+  tag: string;
   balance: bigint;
   decimals: number;
   image: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,10 +1355,10 @@
     d3-scale "^4.0.2"
     react-compound-slider "^3.3.1"
 
-"@chromatic-protocol/sdk-viem@^0.1.0-rc.159":
-  version "0.1.0-rc.159"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.159.tgz#d0dab100c0475d4f18ed366c4f8b13228305421a"
-  integrity sha512-9l0LkniZjXByuvFrxBwDvx2y1N1coS9zjw+mpaltd9yafb7Iq2cjiMIIPhL2ceC5Jf3Cwt9tUOhziphFnND8MA==
+"@chromatic-protocol/sdk-viem@^0.1.0-rc.160":
+  version "0.1.0-rc.160"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/sdk-viem/-/sdk-viem-0.1.0-rc.160.tgz#1c05a1be12a365520401fca5d6ce977faa71604a"
+  integrity sha512-2oOxVHdzRbzH9TyEDejvu3oxYTZ9gViasQVAYm3TH3AR+2rBMXajSC31Qb33r5gwjptrgfWdkrdfhL4+GcAHFA==
   dependencies:
     viem "^1.12.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,10 +1340,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chromatic-protocol/liquidity-provider-sdk@^1.0.1-rc.25":
-  version "1.0.1-rc.25"
-  resolved "https://registry.yarnpkg.com/@chromatic-protocol/liquidity-provider-sdk/-/liquidity-provider-sdk-1.0.1-rc.25.tgz#d7ebf49af699a809d8c803bceb4dd97c66acc580"
-  integrity sha512-ShKf+Vu1OiTicp6AP8aYs5q9wOswTzOVXsZ0VzCxOgMViEi28smT8owk0lbCKYbGxJEhnbVEA0HlEfBDXggApw==
+"@chromatic-protocol/liquidity-provider-sdk@^1.0.1-rc.27":
+  version "1.0.1-rc.27"
+  resolved "https://registry.yarnpkg.com/@chromatic-protocol/liquidity-provider-sdk/-/liquidity-provider-sdk-1.0.1-rc.27.tgz#eea34019d48d5274ce098e82786bf0a58172e3b0"
+  integrity sha512-Q8YFKYiOqqSJhUu/vQr8AJcF7KcW6oPxbyyHnIg2gcNhGm8C73T+jYGPyLxBCBsFZx6cxxtaKJ6kR0MF4gzlvg==
   dependencies:
     viem "^1.5.0"
 


### PR DESCRIPTION
## Description

- Show tags on each LP menus
- Show tags on LP panel
- Store LP address when clicking menus on pool v3 page
- Order LPs with provided orders decided by risk

- Listen events from LP contracts
  - AddLiquidity 
  - AddLiquiditySettled 
  - RemoveLiquidity 
  - RemoveLiquiditySettled
  - Update LP receipts when events fired

- Remove token prices in USD
  - Unable to use with several tokens

- Update amounts by clicking options on trade page

## Related Issues

fixes #552 