### PR TITLE
fix: Frontend QA

### DIFF
--- a/codegen/index.ts
+++ b/codegen/index.ts
@@ -24,6 +24,10 @@ const CONFIG = {
       input: 'string',
       output: 'string',
     },
+    numeric: {
+      input: 'string',
+      output: 'string',
+    },
   },
 };
 

--- a/codegen/index.ts
+++ b/codegen/index.ts
@@ -24,10 +24,6 @@ const CONFIG = {
       input: 'string',
       output: 'string',
     },
-    numeric: {
-      input: 'string',
-      output: 'string',
-    },
   },
 };
 

--- a/src/hooks/useAddChromaticLp.ts
+++ b/src/hooks/useAddChromaticLp.ts
@@ -4,7 +4,6 @@ import { toast } from 'react-toastify';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
-import { dispatchLpEvent } from '~/typings/events';
 import { useChromaticClient } from './useChromaticClient';
 import { useMarket } from './useMarket';
 
@@ -36,9 +35,6 @@ export const useAddChromaticLp = () => {
       }
       const receipt = await lp.addLiquidity(selectedLp.address, parsedAmount, address);
 
-      dispatchLpEvent();
-
-      toast('Add completed.');
       setIsAddPending(false);
     } catch (error) {
       setIsAddPending(false);

--- a/src/hooks/useAddChromaticLp.ts
+++ b/src/hooks/useAddChromaticLp.ts
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
+import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
 import { useMarket } from './useMarket';
 
@@ -12,6 +13,7 @@ export const useAddChromaticLp = () => {
   const { currentMarket } = useMarket();
   const { address } = useAccount();
   const selectedLp = useAppSelector((state) => state.lp.selectedLp);
+  const { fetchBalances } = useChromaticAccount();
   const [isAddPending, setIsAddPending] = useState(false);
 
   const onAddChromaticLp = async (amount: string) => {
@@ -34,6 +36,7 @@ export const useAddChromaticLp = () => {
         throw new Error('Settlement token approval failed.');
       }
       const receipt = await lp.addLiquidity(selectedLp.address, parsedAmount, address);
+      await fetchBalances();
 
       setIsAddPending(false);
     } catch (error) {

--- a/src/hooks/useCLPPerformace.ts
+++ b/src/hooks/useCLPPerformace.ts
@@ -2,6 +2,7 @@ import useSWR from 'swr';
 import { performanceSdk } from '~/lib/graphql';
 import { useAppSelector } from '~/store';
 import { checkAllProps } from '~/utils';
+import { numberFormat } from '~/utils/number';
 import { useError } from './useError';
 
 const periods = ['d7', 'd30', 'd90', 'd180', 'd365', 'all'] as const;
@@ -23,9 +24,14 @@ export const useCLPPerformance = () => {
 
     const performaces = periods.reduce((performances, period) => {
       const profit = response.lp_performances_by_pk?.[`rate_${period}`];
-      performances[period] = BigInt(profit ?? 0);
+      performances[period] = numberFormat(profit ?? '0', {
+        minDigits: 2,
+        maxDigits: 2,
+        roundingMode: 'trunc',
+        type: 'string',
+      });
       return performances;
-    }, {} as Record<Period, bigint>);
+    }, {} as Record<Period, string>);
 
     return performaces;
   });

--- a/src/hooks/useChromaticAccount.ts
+++ b/src/hooks/useChromaticAccount.ts
@@ -88,7 +88,8 @@ export const useChromaticAccount = () => {
       return balances;
     },
     {
-      refreshInterval: 3000,
+      // TODO: Find proper interval seconds
+      refreshInterval: 1000 * 12,
     }
   );
 

--- a/src/hooks/useChromaticLp.ts
+++ b/src/hooks/useChromaticLp.ts
@@ -209,6 +209,7 @@ export const useChromaticLp = () => {
     data: lpList,
     error,
     isLoading: isLpLoading,
+    mutate,
   } = useSWR(
     isReady && checkAllProps(fetchKey) ? { ...fetchKey, walletAddress } : undefined,
     async ({ walletAddress, market, tokens }) => {
@@ -245,7 +246,11 @@ export const useChromaticLp = () => {
     toast('Liquidity provider is selected.');
   };
 
+  const refreshChromaticLp = () => {
+    mutate();
+  };
+
   useError({ error });
 
-  return { lpList, isLpLoading, onLpSelect };
+  return { lpList, isLpLoading, onLpSelect, fetchChromaticLp, refreshChromaticLp };
 };

--- a/src/hooks/useClosePosition.ts
+++ b/src/hooks/useClosePosition.ts
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { Address } from 'wagmi';
 import { AppError } from '~/typings/error';
 import { errorLog } from '~/utils/log';
+import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
 import { usePositions } from './usePositions';
 
@@ -15,6 +16,7 @@ function useClosePosition(props: Props) {
   const { marketAddress, positionId } = props;
   const { client } = useChromaticClient();
   const { positions, fetchPositions, fetchCurrentPositions } = usePositions();
+  const { fetchBalances } = useChromaticAccount();
 
   async function onClosePosition() {
     const position = positions?.find(
@@ -30,6 +32,7 @@ function useClosePosition(props: Props) {
       await routerApi?.closePosition(position.marketAddress, position.id);
 
       await fetchCurrentPositions();
+      await fetchBalances();
       toast('The closing process has been started.');
     } catch (error) {
       errorLog(error);

--- a/src/hooks/useLiquidityPool.ts
+++ b/src/hooks/useLiquidityPool.ts
@@ -94,7 +94,9 @@ export const useLiquidityPool = (marketAddress?: Address) => {
       const lensApi = client.lens();
       const marketApi = client.market();
 
-      return getLiquidityPool(marketApi, lensApi, marketAddress);
+      const pool = await getLiquidityPool(marketApi, lensApi, marketAddress);
+
+      return pool;
     },
     { keepPreviousData: false, dedupingInterval: 8000 }
   );

--- a/src/hooks/useLpReceiptCount.ts
+++ b/src/hooks/useLpReceiptCount.ts
@@ -2,21 +2,21 @@ import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 import { useAccount } from 'wagmi';
 import { checkAllProps } from '~/utils';
-import { useChromaticLp } from './useChromaticLp';
 import { useError } from './useError';
 
 import { lpGraphSdk } from '~/lib/graphql';
+import { useAppSelector } from '~/store';
 
 export const useLpReceiptCount = () => {
   const { address: walletAddress } = useAccount();
-  const { lpList, isLpLoading } = useChromaticLp();
-  const lpAddresses = useMemo(() => {
-    return lpList?.map((lp) => lp.address);
-  }, [lpList]);
+  const selectedLp = useAppSelector((state) => state.lp.selectedLp);
+  const lpAddress = useMemo(() => {
+    return selectedLp?.address;
+  }, [selectedLp]);
 
   const fetchKey = {
     key: 'getLpReceiptCount',
-    lpAddresses,
+    lpAddress,
     walletAddress,
   };
   const {
@@ -26,34 +26,31 @@ export const useLpReceiptCount = () => {
     mutate,
   } = useSWR(
     checkAllProps(fetchKey) ? fetchKey : null,
-    async ({ lpAddresses, walletAddress }) => {
+    async ({ lpAddress, walletAddress }) => {
       let mintings = 0;
       let burnings = 0;
       let inProgresses = 0;
-      for (let index = 0; index < lpAddresses.length; index++) {
-        const lpAddress = lpAddresses[index];
 
-        const { addLiquidities } = await lpGraphSdk.AddLiquidityCount({ walletAddress, lpAddress });
-        const { addLiquiditySettleds } = await lpGraphSdk.AddLiquiditySettledCount({
-          lpAddress,
-          walletAddress,
-        });
-        const { removeLiquidities } = await lpGraphSdk.RemoveLiquidityCount({
-          walletAddress,
-          lpAddress,
-        });
-        const { removeLiquiditySettleds } = await lpGraphSdk.RemoveLiquiditySettledCount({
-          lpAddress,
-          walletAddress,
-        });
+      const { addLiquidities } = await lpGraphSdk.AddLiquidityCount({ walletAddress, lpAddress });
+      const { addLiquiditySettleds } = await lpGraphSdk.AddLiquiditySettledCount({
+        lpAddress,
+        walletAddress,
+      });
+      const { removeLiquidities } = await lpGraphSdk.RemoveLiquidityCount({
+        walletAddress,
+        lpAddress,
+      });
+      const { removeLiquiditySettleds } = await lpGraphSdk.RemoveLiquiditySettledCount({
+        lpAddress,
+        walletAddress,
+      });
 
-        mintings += addLiquidities.length;
-        burnings += removeLiquidities.length;
-        inProgresses +=
-          addLiquidities.length +
-          removeLiquidities.length -
-          (addLiquiditySettleds.length + removeLiquiditySettleds.length);
-      }
+      mintings += addLiquidities.length;
+      burnings += removeLiquidities.length;
+      inProgresses +=
+        addLiquidities.length +
+        removeLiquidities.length -
+        (addLiquiditySettleds.length + removeLiquiditySettleds.length);
       return {
         mintings,
         burnings,

--- a/src/hooks/useLpReceiptCount.ts
+++ b/src/hooks/useLpReceiptCount.ts
@@ -29,6 +29,8 @@ export const useLpReceiptCount = () => {
     async ({ lpAddress, walletAddress }) => {
       let mintings = 0;
       let burnings = 0;
+      let mintingSettleds = 0;
+      let burningSettleds = 0;
       let inProgresses = 0;
 
       const { addLiquidities } = await lpGraphSdk.AddLiquidityCount({ walletAddress, lpAddress });
@@ -47,18 +49,20 @@ export const useLpReceiptCount = () => {
 
       mintings += addLiquidities.length;
       burnings += removeLiquidities.length;
-      inProgresses +=
-        addLiquidities.length +
-        removeLiquidities.length -
-        (addLiquiditySettleds.length + removeLiquiditySettleds.length);
+      mintingSettleds += addLiquiditySettleds.length;
+      burningSettleds += removeLiquiditySettleds.length;
+      inProgresses = mintings + burnings - (mintingSettleds + burningSettleds);
       return {
         mintings,
         burnings,
+        mintingSettleds,
+        burningSettleds,
         inProgresses,
       };
     },
     {
-      refreshInterval: 0,
+      // TODO: Find proper interval seconds
+      refreshInterval: 1000 * 24,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
       revalidateOnFocus: false,

--- a/src/hooks/useLpReceiptEvent.ts
+++ b/src/hooks/useLpReceiptEvent.ts
@@ -1,8 +1,9 @@
 import { iChromaticLpABI } from '@chromatic-protocol/liquidity-provider-sdk/contracts';
 import { isNil, isNotNil } from 'ramda';
 import { useEffect, useMemo, useRef } from 'react';
+import { toast } from 'react-toastify';
 import { useAccount } from 'wagmi';
-import { dispatchLpReceiptEvent } from '~/typings/events';
+import { dispatchLpEvent, dispatchLpReceiptEvent } from '~/typings/events';
 import { useChromaticClient } from './useChromaticClient';
 import { useChromaticLp } from './useChromaticLp';
 
@@ -76,6 +77,8 @@ export const useLpReceiptEvent = () => {
               log.args.recipient === address
           );
           if (filteredLogs.length > 0) {
+            toast('Add completed.');
+            dispatchLpEvent();
             dispatchLpReceiptEvent();
           }
         },
@@ -142,6 +145,8 @@ export const useLpReceiptEvent = () => {
               log.args.recipient === address
           );
           if (filteredLogs.length > 0) {
+            toast('Removal completed.');
+            dispatchLpEvent();
             dispatchLpReceiptEvent();
           }
         },

--- a/src/hooks/useLpReceipts.ts
+++ b/src/hooks/useLpReceipts.ts
@@ -334,7 +334,8 @@ export const useLpReceipts = (props: UseLpReceipts) => {
       return receiptsData;
     },
     {
-      refreshInterval: 0,
+      // TODO: Find proper interval seconds
+      refreshInterval: 1000 * 24,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
       revalidateOnFocus: false,

--- a/src/hooks/useLpReceipts.ts
+++ b/src/hooks/useLpReceipts.ts
@@ -359,6 +359,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
 
   return {
     receiptsData,
+    isReceiptsLoading: isLoading,
     onFetchNextLpReceipts,
     onRefreshLpReceipts,
   };

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -136,8 +136,8 @@ export const usePositions = () => {
     }
   );
 
-  function fetchCurrentPositions() {
-    fetchPositions<Position[]>(async (positions) => {
+  async function fetchCurrentPositions() {
+    await fetchPositions<Position[]>(async (positions) => {
       if (
         isNil(positions) ||
         isNil(accountAddress) ||

--- a/src/hooks/useRemoveChromaticLp.ts
+++ b/src/hooks/useRemoveChromaticLp.ts
@@ -4,7 +4,6 @@ import { toast } from 'react-toastify';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
-import { dispatchLpEvent } from '~/typings/events';
 import { useChromaticClient } from './useChromaticClient';
 
 export const useRemoveChromaticLp = () => {
@@ -33,9 +32,6 @@ export const useRemoveChromaticLp = () => {
         throw new Error('CLP approval failed.');
       }
       const receipt = await lp.removeLiquidity(selectedLp.address, parsedAmount);
-
-      dispatchLpEvent();
-      toast('Removal completed.');
 
       setIsRemovalPending(false);
     } catch (error) {

--- a/src/hooks/useRemoveChromaticLp.ts
+++ b/src/hooks/useRemoveChromaticLp.ts
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
+import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
 
 export const useRemoveChromaticLp = () => {
@@ -11,6 +12,7 @@ export const useRemoveChromaticLp = () => {
   const { address } = useAccount();
   const selectedLp = useAppSelector((state) => state.lp.selectedLp);
   const [isRemovalPending, setIsRemovalPending] = useState(false);
+  const { fetchBalances } = useChromaticAccount();
 
   const onRemoveChromaticLp = async (amount: string) => {
     try {
@@ -32,6 +34,7 @@ export const useRemoveChromaticLp = () => {
         throw new Error('CLP approval failed.');
       }
       const receipt = await lp.removeLiquidity(selectedLp.address, parsedAmount);
+      await fetchBalances();
 
       setIsRemovalPending(false);
     } catch (error) {

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -48,10 +48,16 @@ export const usePoolProgressV2 = () => {
       }
     }
   }, [count, receiptAction, receipts]);
-  const { state: isGuideOpen, setState: setIsGuideOpen } = useLocalStorage(
+  const { state: storedIsGuideOpen, setState: setIsGuideOpen } = useLocalStorage(
     'app:isLpGuideOpen',
     false
   );
+  const isGuideOpen = useMemo(() => {
+    if (!storedIsGuideOpen) {
+      return storedIsGuideOpen;
+    }
+    return receipts.filter((receipt) => !receipt.isSettled).length > 0;
+  }, [storedIsGuideOpen, receipts]);
   const onActionChange = (tabIndex: number) => {
     switch (tabIndex) {
       case 0: {

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -24,6 +24,8 @@ export const usePoolProgressV2 = () => {
     count = {
       mintings: 0,
       burnings: 0,
+      mintingSettleds: 0,
+      burningSettleds: 0,
       inProgresses: 0,
     },
     isCountLoading,
@@ -52,12 +54,20 @@ export const usePoolProgressV2 = () => {
     'app:isLpGuideOpen',
     false
   );
-  const isGuideOpen = useMemo(() => {
+  const isGuideOpens = useMemo(() => {
     if (!storedIsGuideOpen) {
-      return storedIsGuideOpen;
+      return {
+        all: false,
+        minting: false,
+        burning: false,
+      };
     }
-    return receipts.filter((receipt) => !receipt.isSettled).length > 0;
-  }, [storedIsGuideOpen, receipts]);
+    return {
+      all: count.inProgresses > 0,
+      minting: count.mintings > count.mintingSettleds,
+      burning: count.burnings > count.burningSettleds,
+    };
+  }, [storedIsGuideOpen, count]);
   const onActionChange = (tabIndex: number) => {
     switch (tabIndex) {
       case 0: {

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -1,5 +1,7 @@
 import { isNil, isNotNil } from 'ramda';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useChromaticAccount } from '~/hooks/useChromaticAccount';
+import { useChromaticLp } from '~/hooks/useChromaticLp';
 import { useLastOracle } from '~/hooks/useLastOracle';
 import useLocalStorage from '~/hooks/useLocalStorage';
 import { useLpReceiptCount } from '~/hooks/useLpReceiptCount';
@@ -10,16 +12,18 @@ import { LpReceipt } from '~/typings/lp';
 export const usePoolProgressV2 = () => {
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const ref = useRef<HTMLDivElement>(null);
-
+  const { fetchBalances } = useChromaticAccount();
   const { formattedElapsed } = useLastOracle();
   const [receiptAction, setReceiptAction] = useState('all' as 'all' | 'minting' | 'burning');
   const {
     receiptsData = [],
+    isReceiptsLoading,
     onFetchNextLpReceipts,
     onRefreshLpReceipts,
   } = useLpReceipts({
     currentAction: receiptAction,
   });
+  const { refreshChromaticLp } = useChromaticLp();
   const {
     count = {
       mintings: 0,
@@ -103,17 +107,20 @@ export const usePoolProgressV2 = () => {
     function onLpReceiptRefresh() {
       onRefreshLpReceipts();
       onRefreshLpReceiptCount();
+
+      fetchBalances();
+      refreshChromaticLp();
     }
     window.addEventListener(LP_RECEIPT_EVENT, onLpReceiptRefresh);
     return () => {
       window.removeEventListener(LP_RECEIPT_EVENT, onLpReceiptRefresh);
     };
-  }, [onRefreshLpReceipts, onRefreshLpReceiptCount]);
+  }, [onRefreshLpReceipts, onRefreshLpReceiptCount, fetchBalances, refreshChromaticLp]);
 
   return {
     openButtonRef,
     ref,
-    isGuideOpen,
+    isGuideOpens,
     formattedElapsed,
     receipts,
     receiptAction,

--- a/src/stories/molecule/PoolProgressV2/index.tsx
+++ b/src/stories/molecule/PoolProgressV2/index.tsx
@@ -22,7 +22,7 @@ export function PoolProgressV2() {
     ref,
     formattedElapsed,
     receipts = [],
-    isGuideOpen,
+    isGuideOpens,
     count,
     receiptAction,
     hasMoreReceipts,
@@ -77,7 +77,7 @@ export function PoolProgressV2() {
                     <Tab.Panels className="flex-auto">
                       <div className="mb-1">
                         <Guide
-                          isVisible={isGuideOpen}
+                          isVisible={isGuideOpens[receiptAction]}
                           title="The process is in progress. You may leave now."
                           // The percentage value in the paragraph is a value that is different for each market.
                           paragraph="The liquidity provision process is now waiting for next oracle round. The CLP tokens will be sent to your wallet when the process completed."
@@ -118,11 +118,13 @@ export function PoolProgressV2() {
                       </Tab.Panel>
                       {/* tab - minting */}
                       <Tab.Panel className="flex flex-col mb-5">
-                        {/* {mintingSize === 0 ? (
-                        <p className="my-6 text-center text-primary/20">
-                          There is no liquidity add history.
-                        </p>
-                      ) : ( */}
+                        {count.mintings === 0 ? (
+                          <p className="my-6 text-center text-primary/20">
+                            There is no liquidity add history.
+                          </p>
+                        ) : (
+                          <></>
+                        )}
                         {
                           <>
                             {receipts.map((receipt) => (
@@ -145,11 +147,13 @@ export function PoolProgressV2() {
                       </Tab.Panel>
                       {/* tab - burning */}
                       <Tab.Panel className="flex flex-col mb-5">
-                        {/* {burningSize === 0 ? (
-                        <p className="my-6 text-center text-primary/20">
-                          There is no liquidity remove history.
-                        </p>
-                      ) : ( */}
+                        {count.burnings === 0 ? (
+                          <p className="my-6 text-center text-primary/20">
+                            There is no liquidity remove history.
+                          </p>
+                        ) : (
+                          <></>
+                        )}
                         {
                           <>
                             {receipts.map((receipt) => (

--- a/src/stories/template/PoolPanelV2/index.tsx
+++ b/src/stories/template/PoolPanelV2/index.tsx
@@ -9,7 +9,6 @@ import { OptionInput } from '~/stories/atom/OptionInput';
 import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import '~/stories/atom/Tabs/style.css';
 import { Thumbnail } from '~/stories/atom/Thumbnail';
-import { TooltipAlert } from '~/stories/atom/TooltipAlert';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { PoolProgressV2 } from '~/stories/molecule/PoolProgressV2';
 
@@ -37,10 +36,10 @@ export function PoolPanelV2() {
 
     isAssetsLoading,
     isLpLoading,
-    isExceeded,
-    amount,
-    maxAmount,
-    formattedBalance,
+    isExceededs,
+    amounts,
+    maxAmounts,
+    formattedBalances,
     formattedClp,
     isAddPending,
     isRemovalPending,
@@ -125,7 +124,7 @@ export function PoolPanelV2() {
                         <h4 className="text-xl">Wallet Balance</h4>
                         <p className="text-lg text-primary-light">
                           <SkeletonElement isLoading={isAssetsLoading} width={40}>
-                            {formattedBalance} {tokenName}
+                            {formattedBalances.add} {tokenName}
                           </SkeletonElement>
                         </p>
                       </div>
@@ -138,11 +137,11 @@ export function PoolPanelV2() {
                     {/* - TooltipAlert : is shown when has error */}
                     <div className="tooltip-wallet-balance">
                       <OptionInput
-                        value={amount}
-                        maxValue={maxAmount}
+                        value={amounts.add}
+                        maxValue={maxAmounts.add}
                         onChange={onAmountChange}
-                        error={isExceeded}
-                        errorMsg={isExceeded ? 'Exceeded your wallet balance.' : undefined}
+                        error={isExceededs.add}
+                        errorMsg={isExceededs.add ? 'Exceeded your wallet balance.' : undefined}
                         assetSrc={tokenImage}
                         size="lg"
                       />
@@ -205,12 +204,12 @@ export function PoolPanelV2() {
                       css="active"
                       size="2xl"
                       onClick={() => {
-                        if (amount === '') {
+                        if (amounts.add === '') {
                           return;
                         }
-                        onAddChromaticLp(amount);
+                        onAddChromaticLp(amounts.add);
                       }}
-                      disabled={isAddPending}
+                      disabled={isExceededs.add || isAddPending}
                     />
                   </div>
                 </article>
@@ -263,11 +262,13 @@ export function PoolPanelV2() {
                               </div>
                               <div className="tooltip-wallet-balance">
                                 <OptionInput
-                                  value={amount}
-                                  maxValue={maxAmount}
+                                  value={amounts.remove}
+                                  maxValue={maxAmounts.remove}
                                   onChange={onAmountChange}
-                                  error={isExceeded}
-                                  errorMsg={isExceeded ? 'Exceeded your CLP balance.' : undefined}
+                                  error={isExceededs.remove}
+                                  errorMsg={
+                                    isExceededs.remove ? 'Exceeded your CLP balance.' : undefined
+                                  }
                                   assetSrc={clpImage}
                                   size="lg"
                                 />
@@ -303,12 +304,12 @@ export function PoolPanelV2() {
                                 css="active"
                                 size="2xl"
                                 onClick={() => {
-                                  if (amount === '') {
+                                  if (amounts.remove === '') {
                                     return;
                                   }
-                                  onRemoveChromaticLp(amount);
+                                  onRemoveChromaticLp(amounts.remove);
                                 }}
-                                disabled={isRemovalPending}
+                                disabled={isExceededs.remove || isRemovalPending}
                               />
                             </div>
                           </article>

--- a/src/stories/template/PoolPerformance/hooks.ts
+++ b/src/stories/template/PoolPerformance/hooks.ts
@@ -1,8 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import { FEE_RATE_DECIMAL } from '~/configs/decimals';
 import { useCLPPerformance } from '~/hooks/useCLPPerformace';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
-import { formatDecimals } from '~/utils/number';
 
 const formattedPeriods = ['A week', 'A month', '3 months', '6 months', 'A year', 'All time'];
 
@@ -12,12 +10,12 @@ export const usePoolPerformance = () => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { performance, period } = useMemo(() => {
     const period = periods[selectedIndex];
-    const performance = formatDecimals(performances?.[period], FEE_RATE_DECIMAL, 2);
+    const performance = (performances?.[period] ?? '0') + '%';
 
     return { period, performance };
   }, [selectedIndex, periods, performances]);
   const trailingApr = useMemo(() => {
-    return formatDecimals(performances?.['d365'], FEE_RATE_DECIMAL, 2);
+    return (performances?.['d365'] ?? '0') + '%';
   }, [performances]);
 
   const onPeriodChange = useCallback((nextIndex: number) => {

--- a/src/stories/template/PoolPerformance/index.tsx
+++ b/src/stories/template/PoolPerformance/index.tsx
@@ -68,7 +68,7 @@ export const PoolPerformance = (props: PoolPerformanceProps) => {
                 />
               </div>
               {/* todo: text price color */}
-              <h4 className="text-price-higher mt-[2px]">{performance}%</h4>
+              <h4 className="text-price-higher mt-[2px]">{performance}</h4>
             </div>
           </div>
           <div className="flex w-1/2 gap-3 pl-5 border-l">
@@ -83,7 +83,7 @@ export const PoolPerformance = (props: PoolPerformanceProps) => {
                 />
               </div>
               {/* todo: text price color */}
-              <h4 className="text-price-higher mt-[2px]">{trailingApr}%</h4>
+              <h4 className="text-price-higher mt-[2px]">{trailingApr}</h4>
             </div>
           </div>
         </div>

--- a/src/stories/template/TradeManagementV3/hooks.ts
+++ b/src/stories/template/TradeManagementV3/hooks.ts
@@ -19,7 +19,7 @@ import { abs, divPreserved, formatDecimals } from '~/utils/number';
 
 export function useTradeManagementV3() {
   const { currentMarket } = useMarket();
-  const { positions, isLoading } = usePositions();
+  const { positions, isLoading, fetchCurrentPositions } = usePositions();
   const { historyData, isLoading: isHistoryLoading, onFetchNextHistory } = useTradeHistory();
   const { tradesData, isLoading: isTradeLogsLoading, onFetchNextTrade } = useTradeLogs();
   const { initialBlockNumber } = useInitialBlockNumber();
@@ -38,9 +38,11 @@ export function useTradeManagementV3() {
     if (previousOracle !== currentMarket.oracleValue.version) {
       if (isNotNil(openingPositionSize) && openingPositionSize > 0) {
         toast.info('The opening process has been completed.');
+        fetchCurrentPositions();
       }
       if (isNotNil(closingPositionSize) && closingPositionSize > 0) {
         toast.info('The closing process has been completed.');
+        fetchCurrentPositions();
       }
     }
   }, [currentMarket, previousOracle, openingPositionSize, closingPositionSize]);

--- a/src/stories/template/TradeManagementV3/hooks.ts
+++ b/src/stories/template/TradeManagementV3/hooks.ts
@@ -2,6 +2,7 @@ import { isNil, isNotNil } from 'ramda';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { ORACLE_PROVIDER_DECIMALS, PERCENT_DECIMALS, PNL_RATE_DECIMALS } from '~/configs/decimals';
+import { useChromaticAccount } from '~/hooks/useChromaticAccount';
 import { useInitialBlockNumber } from '~/hooks/useInitialBlockNumber';
 
 import { useLastOracle } from '~/hooks/useLastOracle';
@@ -23,6 +24,7 @@ export function useTradeManagementV3() {
   const { historyData, isLoading: isHistoryLoading, onFetchNextHistory } = useTradeHistory();
   const { tradesData, isLoading: isTradeLogsLoading, onFetchNextTrade } = useTradeLogs();
   const { initialBlockNumber } = useInitialBlockNumber();
+  const { fetchBalances } = useChromaticAccount();
   const previousOracle = usePrevious(currentMarket?.oracleValue.version);
   const openingPositionSize = usePrevious(
     positions?.filter((position) => position.status === POSITION_STATUS.OPENING).length ?? 0
@@ -39,13 +41,22 @@ export function useTradeManagementV3() {
       if (isNotNil(openingPositionSize) && openingPositionSize > 0) {
         toast.info('The opening process has been completed.');
         fetchCurrentPositions();
+        fetchBalances();
       }
       if (isNotNil(closingPositionSize) && closingPositionSize > 0) {
         toast.info('The closing process has been completed.');
         fetchCurrentPositions();
+        fetchBalances();
       }
     }
-  }, [currentMarket, previousOracle, openingPositionSize, closingPositionSize]);
+  }, [
+    currentMarket,
+    previousOracle,
+    openingPositionSize,
+    closingPositionSize,
+    fetchBalances,
+    fetchCurrentPositions,
+  ]);
 
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Description

- Fetch LP receipts by selected lp only
- Listen LP events with event names
  - Fetch LP receipts when events listened
  - Set interval seconds to fetch LP receipts

- Format CLP performances
- Show guides if receipts not settled exist
- Fetch positions after oracle version update

- Fetch balances after transactions
  - Add or remove into LP
  - Open and close positions

- Disable buttons if amounts is more than balances in pool panels

## Related Issues

fixes #571 