### PR TITLE
hotfix: Liquidity bins & positions

### DIFF
--- a/src/hooks/useAddChromaticLp.ts
+++ b/src/hooks/useAddChromaticLp.ts
@@ -39,7 +39,7 @@ export const useAddChromaticLp = () => {
 
       dispatchLpEvent();
       dispatchLpReceiptEvent();
-      toast('Add completed.');
+      toast('Add process started.');
       setIsAddPending(false);
     } catch (error) {
       setIsAddPending(false);

--- a/src/hooks/useLiquidityPool.ts
+++ b/src/hooks/useLiquidityPool.ts
@@ -2,6 +2,7 @@ import type { ChromaticLens } from '@chromatic-protocol/sdk-viem';
 import { utils as ChromaticUtils } from '@chromatic-protocol/sdk-viem';
 import { isNil, isNotNil } from 'ramda';
 import { useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
 import { Address } from 'wagmi';
 import { poolsAction } from '~/store/reducer/pools';
@@ -71,8 +72,20 @@ export const useLiquidityPool = (marketAddress?: Address, tokenAddress?: Address
   const currentMarketAddress = marketAddress || currentMarket?.address;
   const currentTokenAddress = tokenAddress || currentToken?.address;
   const isPositionsReady = useAppSelector(isPositionsReadySelector);
+  const isLpReady = useAppSelector(isLpReadySelector);
   const previousMarketAddress = usePrevious(currentMarketAddress);
   const { isReady, client } = useChromaticClient();
+  const location = useLocation();
+  const isAssetReady = useMemo(() => {
+    switch (location.pathname) {
+      case '/trade': {
+        return isPositionsReady;
+      }
+      case '/pool': {
+        return isLpReady;
+      }
+    }
+  }, [location.pathname, isLpReady, isPositionsReady]);
 
   const fetchKeyData = {
     name: 'useLiquidityPool',
@@ -86,7 +99,7 @@ export const useLiquidityPool = (marketAddress?: Address, tokenAddress?: Address
     isLoading,
     error,
   } = useSWR(
-    isPositionsReady && isReady && checkAllProps(fetchKeyData) && fetchKeyData,
+    isAssetReady && isReady && checkAllProps(fetchKeyData) && fetchKeyData,
     async ({ marketAddress, tokenAddress }) => {
       const lensApi = client.lens();
 

--- a/src/hooks/useOpenPosition.ts
+++ b/src/hooks/useOpenPosition.ts
@@ -1,4 +1,5 @@
 import { isNil, isNotNil } from 'ramda';
+import { useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { useChromaticAccount } from '~/hooks/useChromaticAccount';
@@ -24,8 +25,10 @@ function useOpenPosition() {
   const {
     liquidity: { longTotalUnusedLiquidity, shortTotalUnusedLiquidity },
   } = useLiquidityPool();
+  const [isLoading, setIsLoading] = useState(false);
 
   async function openPosition(input: TradeInput) {
+    setIsLoading(true);
     if (isNil(input)) {
       toast('Input data needed');
       return;
@@ -82,11 +85,13 @@ function useOpenPosition() {
     } catch (error) {
       toast.error('Transaction rejected.');
     } finally {
+      setIsLoading(false);
       return;
     }
   }
 
   return {
+    isLoading,
     openPosition,
   };
 }

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -17,7 +17,7 @@ import { MarketLike } from '~/typings/market';
 import { OracleVersion } from '~/typings/oracleVersion';
 import { POSITION_STATUS, Position } from '~/typings/position';
 import { Logger } from '~/utils/log';
-import { trimMarkets } from '~/utils/market';
+import { trimMarket, trimMarkets } from '~/utils/market';
 import { divPreserved } from '~/utils/number';
 import { checkAllProps } from '../utils';
 import { PromiseOnlySuccess } from '../utils/promise';
@@ -156,6 +156,7 @@ export const usePositions = () => {
     type: 'EOA',
     markets: trimMarkets(markets),
     entireMarkets: trimMarkets(entireMarkets),
+    currentMarket: trimMarket(currentMarket),
     chromaticAccount: accountAddress,
     filterOption,
   };
@@ -167,7 +168,7 @@ export const usePositions = () => {
     isLoading,
   } = useSWR(
     checkAllProps(fetchKey) && fetchKey,
-    async ({ markets, entireMarkets, filterOption, chromaticAccount }) => {
+    async ({ markets, entireMarkets, currentMarket, filterOption, chromaticAccount }) => {
       const accountApi = client.account();
       const positionApi = client.position();
       const marketApi = client.market();
@@ -177,7 +178,7 @@ export const usePositions = () => {
           ? entireMarkets
           : filterOption === 'TOKEN_BASED'
           ? markets
-          : markets.filter((market) => market.address === currentMarket?.address);
+          : markets.filter((market) => market.address === currentMarket.address);
       return getPositions(accountApi, positionApi, marketApi, filteredMarkets, chromaticAccount);
     }
   );

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -5,15 +5,16 @@ import {
   IPosition as IChromaticPosition,
 } from '@chromatic-protocol/sdk-viem';
 import { isNil, isNotNil } from 'ramda';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
-import { Address, useAccount } from 'wagmi';
+import { Address } from 'wagmi';
 import { ORACLE_PROVIDER_DECIMALS } from '~/configs/decimals';
 import { useChromaticAccount } from '~/hooks/useChromaticAccount';
 import { useEntireMarkets, useMarket } from '~/hooks/useMarket';
 import { useAppDispatch, useAppSelector } from '~/store';
 import { loadedAction } from '~/store/reducer/loaded';
 import { MarketLike } from '~/typings/market';
+import { OracleVersion } from '~/typings/oracleVersion';
 import { POSITION_STATUS, Position } from '~/typings/position';
 import { Logger } from '~/utils/log';
 import { trimMarkets } from '~/utils/market';
@@ -42,25 +43,65 @@ async function getPositions(
   accountApi: ChromaticAccount,
   positionApi: ChromaticPosition,
   marketApi: ChromaticMarket,
-  market: MarketLike,
+  markets: MarketLike[],
   walletAddress: Address
 ) {
-  const positionIds = await accountApi.getPositionIds(market.address);
+  const tuplesPromise = markets
+    .map((market) => {
+      const idsPromise = accountApi.getPositionIds(market.address);
+      const oraclePromise = marketApi.getCurrentPrice(market.address);
+      return [market.address, market.tokenAddress, oraclePromise, idsPromise] as const;
+    })
+    .flat(1);
+  const tuples = await Promise.allSettled(tuplesPromise);
+  const marketOracles = {} as Record<Address, OracleVersion>;
+  const positionIds = [] as [Address, Address, bigint[]][];
+  for (let index = 0; index < tuples.length; index++) {
+    const item = tuples[index];
+    if (item.status === 'rejected') {
+      continue;
+    }
+    const tupleIndex = index % 4;
+    const marketIndex = Math.floor(index / 4);
+    switch (tupleIndex) {
+      case 0: {
+        const marketAddress = item.value as Address;
+        marketOracles[marketAddress] = {} as OracleVersion;
+        positionIds[marketIndex] = [marketAddress, '0x', []];
+        continue;
+      }
+      case 1: {
+        const tokenAddress = item.value as Address;
+        positionIds[marketIndex][1] = tokenAddress;
+        continue;
+      }
+      case 2: {
+        marketOracles[positionIds[marketIndex][0]] = item.value as OracleVersion;
+        continue;
+      }
+      case 3: {
+        positionIds[marketIndex][2] = item.value as bigint[];
+        continue;
+      }
+    }
+  }
+  const positionsResponse = positionIds.map(async ([marketAddress, tokenAddress, ids]) => {
+    const positions = await positionApi.getPositions(marketAddress, [...ids]);
+    return positions.map((position) => ({ ...position, marketAddress, tokenAddress }));
+  });
+  const positions = (await PromiseOnlySuccess(positionsResponse)).flat(1);
 
-  const positions = await positionApi.getPositions(market.address, [...positionIds]);
-  const marketOracle = await marketApi.getCurrentPrice(market.address);
-  const { price: currentPrice, version: currentVersion } = marketOracle;
   const withLiquidation = await PromiseOnlySuccess(
     positions.map(async (position) => {
+      const { price: currentPrice, version: currentVersion } =
+        marketOracles[position.marketAddress];
       const { profitStopPrice = 0n, lossCutPrice = 0n } = await positionApi.getLiquidationPrice(
-        market.address,
+        position.marketAddress,
         position.openPrice,
         position
       );
       return {
         ...position,
-        tokenAddress: market.tokenAddress,
-        marketAddress: market.address,
         lossPrice: lossCutPrice ?? 0n,
         profitPrice: profitStopPrice ?? 0n,
         collateral: position.takerMargin, //TODO ,
@@ -78,10 +119,16 @@ async function getPositions(
     withLiquidation
       .filter((position) => position.owner === walletAddress)
       .map(async (position) => {
+        const { price: currentPrice } = marketOracles[position.marketAddress];
         const targetPrice =
           position.closePrice && position.closePrice !== 0n ? position.closePrice : currentPrice;
         const pnl = position.openPrice
-          ? await positionApi.getPnl(market.address, position.openPrice, targetPrice, position)
+          ? await positionApi.getPnl(
+              position.marketAddress,
+              position.openPrice,
+              targetPrice,
+              position
+            )
           : 0n;
         return {
           ...position,
@@ -102,7 +149,6 @@ export const usePositions = () => {
   const { markets, currentMarket } = useMarket();
   const { client } = useChromaticClient();
   const filterOption = useAppSelector((state) => state.position.filterOption);
-  const { address } = useAccount();
   const dispatch = useAppDispatch();
 
   const fetchKey = {
@@ -132,55 +178,44 @@ export const usePositions = () => {
           : filterOption === 'TOKEN_BASED'
           ? markets
           : markets.filter((market) => market.address === currentMarket?.address);
-      const positionsResponse = await PromiseOnlySuccess(
-        filteredMarkets.map(async (market) => {
-          return getPositions(accountApi, positionApi, marketApi, market, chromaticAccount);
-        })
-      );
-      const flattenPositions = positionsResponse.flat(1);
-      flattenPositions.sort((previous, next) =>
-        previous.openTimestamp < next.openTimestamp ? 1 : -1
-      );
-      return flattenPositions;
+      return getPositions(accountApi, positionApi, marketApi, filteredMarkets, chromaticAccount);
     }
   );
 
-  async function fetchCurrentPositions() {
-    await fetchPositions<Position[]>(
-      async (positions) => {
-        if (
-          isNil(positions) ||
-          isNil(accountAddress) ||
-          isNil(currentMarket) ||
-          isNil(currentToken) ||
-          isNil(address)
-        )
-          return positions;
+  const fetchCurrentPositions = useCallback(async () => {
+    if (isLoading) {
+      return;
+    }
+    if (
+      isNil(positions) ||
+      isNil(accountAddress) ||
+      isNil(currentMarket) ||
+      isNil(currentToken) ||
+      isNil(accountAddress)
+    )
+      return positions;
 
-        const filteredPositions = positions
-          ?.filter((p) => !!p)
-          .filter((position) => position.marketAddress !== currentMarket?.address);
+    const filteredPositions = positions
+      ?.filter((p) => !!p)
+      .filter((position) => position.marketAddress !== currentMarket?.address);
 
-        const accountApi = client.account();
-        const positionApi = client.position();
-        const marketApi = client.market();
+    const accountApi = client.account();
+    const positionApi = client.position();
+    const marketApi = client.market();
 
-        const newPositions = await getPositions(
-          accountApi,
-          positionApi,
-          marketApi,
-          currentMarket,
-          address
-        );
-        const mergedPositions = [...filteredPositions, ...newPositions];
-        mergedPositions.sort((previous, next) =>
-          previous.openTimestamp < next.openTimestamp ? 1 : -1
-        );
-        return mergedPositions;
-      },
-      { revalidate: false }
+    const newPositions = await getPositions(
+      accountApi,
+      positionApi,
+      marketApi,
+      [currentMarket],
+      accountAddress
     );
-  }
+    const mergedPositions = [...filteredPositions, ...newPositions];
+    mergedPositions.sort((previous, next) =>
+      previous.openTimestamp < next.openTimestamp ? 1 : -1
+    );
+    await fetchPositions<Position[]>(mergedPositions, { revalidate: false });
+  }, [client, isLoading, currentToken, currentMarket, positions, accountAddress, fetchPositions]);
 
   const currentPositions = useMemo(() => {
     return positions?.filter(

--- a/src/hooks/useRemoveChromaticLp.ts
+++ b/src/hooks/useRemoveChromaticLp.ts
@@ -37,7 +37,7 @@ export const useRemoveChromaticLp = () => {
 
       dispatchLpEvent();
       dispatchLpReceiptEvent();
-      toast('Removal completed.');
+      toast('Removal process started.');
 
       setIsRemovalPending(false);
     } catch (error) {

--- a/src/hooks/useTradeHistory.ts
+++ b/src/hooks/useTradeHistory.ts
@@ -1,6 +1,7 @@
 import { chromaticAccountABI } from '@chromatic-protocol/sdk-viem/contracts';
 import axios from 'axios';
 import { isNil, isNotNil } from 'ramda';
+import { useCallback } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { decodeEventLog } from 'viem';
 import { Address } from 'wagmi';
@@ -145,6 +146,7 @@ export const useTradeHistory = () => {
     error,
     size,
     setSize,
+    mutate,
   } = useSWRInfinite(
     (pageIndex, previousData) => {
       if (!isReady || isNil(initialBlockNumber)) {
@@ -272,11 +274,16 @@ export const useTradeHistory = () => {
     setSize((size) => size + 1);
   };
 
+  const refreshTradeHistory = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
   useError({ error });
 
   return {
     historyData,
     isLoading,
     onFetchNextHistory,
+    refreshTradeHistory,
   };
 };

--- a/src/hooks/useTradeInput.ts
+++ b/src/hooks/useTradeInput.ts
@@ -1,5 +1,5 @@
 import { isNil } from 'ramda';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { formatUnits, parseUnits } from 'viem';
 
 import { useLiquidityPool } from '~/hooks/useLiquidityPool';
@@ -111,52 +111,51 @@ export const useTradeInput = (props: Props) => {
   const { totalMargin: balance } = useMargins();
   // Traverse bins from low fee rates to high.
   // Derive trade fees by subtracting free liquidities from maker margin.
-  const { tradeFee, feePercent } = useMemo(() => {
-    if (
-      isNil(currentToken) ||
-      (direction === 'long' && state.makerMargin > longTotalUnusedLiquidity) ||
-      (direction === 'short' && state.makerMargin > shortTotalUnusedLiquidity)
-    ) {
-      return { tradeFee: 0n, feePercent: 0n };
-    }
-    const { tradeFee, makerMargin } = (pool?.bins || []).reduce(
-      (acc, cur) => {
-        if (
-          (direction === 'long' && cur.baseFeeRate > 0) ||
-          (direction === 'short' && cur.baseFeeRate < 0) ||
-          acc.makerMargin > 0n
-        ) {
-          const feeRate = abs(cur.baseFeeRate);
+  // { tradeFee, feePercent }
+  const getTradeFee = useCallback(
+    (makerMargin: bigint) => {
+      if (
+        isNil(currentToken) ||
+        (direction === 'long' && makerMargin > longTotalUnusedLiquidity) ||
+        (direction === 'short' && makerMargin > shortTotalUnusedLiquidity)
+      ) {
+        return { tradeFee: 0n, feePercent: 0n };
+      }
+      const { tradeFee } = (pool?.bins || []).reduce(
+        (acc, cur) => {
+          if (
+            (direction === 'long' && cur.baseFeeRate > 0) ||
+            (direction === 'short' && cur.baseFeeRate < 0) ||
+            acc.makerMargin > 0n
+          ) {
+            const feeRate = abs(cur.baseFeeRate);
 
-          if (acc.makerMargin >= cur.freeLiquidity) {
-            acc.tradeFee =
-              acc.tradeFee + mulPreserved(cur.freeLiquidity, feeRate, FEE_RATE_DECIMAL);
-            acc.makerMargin = acc.makerMargin - cur.freeLiquidity;
-          } else {
-            acc.tradeFee = acc.tradeFee + mulPreserved(acc.makerMargin, feeRate, FEE_RATE_DECIMAL);
-            acc.makerMargin = 0n;
+            if (acc.makerMargin >= cur.freeLiquidity) {
+              acc.tradeFee =
+                acc.tradeFee + mulPreserved(cur.freeLiquidity, feeRate, FEE_RATE_DECIMAL);
+              acc.makerMargin = acc.makerMargin - cur.freeLiquidity;
+            } else {
+              acc.tradeFee =
+                acc.tradeFee + mulPreserved(acc.makerMargin, feeRate, FEE_RATE_DECIMAL);
+              acc.makerMargin = 0n;
+            }
           }
-        }
-        return acc;
-      },
-      { tradeFee: 0n, makerMargin: state.makerMargin }
-    );
+          return acc;
+        },
+        { tradeFee: 0n, makerMargin: makerMargin }
+      );
 
-    const feePercent =
-      state.makerMargin === 0n
-        ? tradeFee
-        : divPreserved(tradeFee, state.makerMargin, currentToken.decimals) * 100n;
-    return { tradeFee, feePercent };
-  }, [
-    state.makerMargin,
-    direction,
-    currentToken,
-    pool?.bins,
-    longTotalUnusedLiquidity,
-    shortTotalUnusedLiquidity,
-  ]);
+      const feePercent =
+        makerMargin === 0n
+          ? tradeFee
+          : divPreserved(tradeFee, makerMargin, currentToken.decimals) * 100n;
+      return { tradeFee, feePercent };
+    },
+    [direction, currentToken, pool?.bins, longTotalUnusedLiquidity, shortTotalUnusedLiquidity]
+  );
 
   useEffect(() => {
+    const { feePercent } = getTradeFee(state.makerMargin);
     if (isNil(currentToken) || isNil(feePercent)) return;
 
     const baseFeeAllowance = getBaseFeeAllowance(feePercent, currentToken.decimals);
@@ -167,18 +166,28 @@ export const useTradeInput = (props: Props) => {
     );
 
     onFeeAllowanceChange(maxFeeAllowance);
-  }, [feePercent, currentToken]);
+  }, [getTradeFee, currentToken, state.makerMargin]);
+
+  const { tradeFee, feePercent } = useMemo(
+    () => getTradeFee(state.makerMargin),
+    [getTradeFee, state.makerMargin]
+  );
 
   const onMethodChange = (value: 'collateral' | 'quantity') => {
     dispatch(tradesAction.updateTradesState({ direction, method: value }));
   };
 
-  const onAmountChange = (value: string) => {
+  const onAmountChange = (value: string, hasMax: boolean = false) => {
     const amount = parseUnits(value, currentToken?.decimals || 0);
 
     const { method, takeProfit, stopLoss } = state;
 
-    const calculated = getCalculatedValues({ method, takeProfit, stopLoss, amount });
+    const { makerMargin } = getCalculatedValues({ method, takeProfit, stopLoss, amount });
+
+    const { tradeFee } = getTradeFee(makerMargin);
+    const reducedAmount = amount - tradeFee;
+
+    const calculated = getCalculatedValues({ method, takeProfit, stopLoss, amount: reducedAmount });
 
     const amounts =
       amount === undefined

--- a/src/hooks/useTradeLogs.ts
+++ b/src/hooks/useTradeLogs.ts
@@ -2,6 +2,7 @@ import { Client } from '@chromatic-protocol/sdk-viem';
 import { chromaticAccountABI } from '@chromatic-protocol/sdk-viem/contracts';
 import axios from 'axios';
 import { isNil } from 'ramda';
+import { useCallback } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { decodeEventLog, getEventSelector } from 'viem';
 import { Address } from 'wagmi';
@@ -111,6 +112,7 @@ export const useTradeLogs = () => {
     error,
     size,
     setSize,
+    mutate,
   } = useSWRInfinite(
     (pageIndex, previousData) => {
       if (!isReady || isNil(initialBlockNumber)) {
@@ -211,11 +213,16 @@ export const useTradeLogs = () => {
     setSize((size) => size + 1);
   };
 
+  const refreshTradeLogs = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
   useError({ error });
 
   return {
     tradesData,
     isLoading,
     onFetchNextTrade,
+    refreshTradeLogs,
   };
 };

--- a/src/lib/pyth/streaming.ts
+++ b/src/lib/pyth/streaming.ts
@@ -116,9 +116,9 @@ export async function startStreaming() {
 }
 
 function getNextDailyBarTime(barTime: number) {
-  const date = new Date(barTime * 1000);
+  const date = new Date(barTime);
   date.setDate(date.getDate() + 1);
-  return date.getTime() / 1000;
+  return date.getTime();
 }
 
 export function subscribeOnStream(

--- a/src/stories/atom/OptionInput/index.tsx
+++ b/src/stories/atom/OptionInput/index.tsx
@@ -22,7 +22,7 @@ interface OptionInputProps {
   errorMsg?: string | undefined;
   errorMsgAlign?: 'left' | 'center' | 'right';
   onClick?: () => unknown;
-  onChange?: (value: string) => unknown;
+  onChange?: (value: string, hasMax?: boolean) => unknown;
 }
 
 export const OptionInput = (props: OptionInputProps) => {
@@ -48,7 +48,7 @@ export const OptionInput = (props: OptionInputProps) => {
   const onClick = (ratio: 25 | 50 | 75 | 100) => () => {
     setRatio(ratio);
     if (ratio === 100) {
-      onChange?.(String(maxValue || ''));
+      onChange?.(String(maxValue || ''), true);
     } else {
       const nextValue = Number(maxValue) * (ratio / 100);
       onChange?.(String(nextValue || ''));

--- a/src/stories/molecule/AmountSwitch/index.tsx
+++ b/src/stories/molecule/AmountSwitch/index.tsx
@@ -1,6 +1,5 @@
 // import { Input } from '~/stories/atom/Input';
 import { OptionInput } from '~/stories/atom/OptionInput';
-import { TooltipAlert } from '~/stories/atom/TooltipAlert';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { numberFormat } from '~/utils/number';
 
@@ -16,7 +15,7 @@ interface AmountSwitchProps {
   minAmount: string;
   maxAmount: string | number;
   optionInputDirection?: 'row' | 'column';
-  onAmountChange: (value: string) => unknown;
+  onAmountChange: (value: string, hasMax?: boolean) => unknown;
 }
 
 export const AmountSwitch = (props: AmountSwitchProps) => {

--- a/src/stories/molecule/TradeContentV3/hooks.tsx
+++ b/src/stories/molecule/TradeContentV3/hooks.tsx
@@ -124,7 +124,7 @@ export function useTradeContentV3(props: TradeContentV3Props) {
   const maxFeeAllowance = input?.maxFeeAllowance;
   const minMaxFeeAllowance = +tradeFeePercent;
 
-  const { openPosition } = useOpenPosition();
+  const { openPosition, isLoading: isOpenPending } = useOpenPosition();
 
   function onOpenPosition() {
     openPosition({ ...input, direction }).then(() => {
@@ -236,5 +236,6 @@ export function useTradeContentV3(props: TradeContentV3Props) {
     stopLossPrice,
 
     onOpenPosition,
+    isOpenPending,
   };
 }

--- a/src/stories/molecule/TradeContentV3/index.tsx
+++ b/src/stories/molecule/TradeContentV3/index.tsx
@@ -81,6 +81,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
     stopLossPrice,
 
     onOpenPosition,
+    isOpenPending,
   } = useTradeContentV3(props);
 
   return (
@@ -290,7 +291,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
               size="2xl"
               className="w-full !font-bold"
               css={isLong ? 'long' : 'short'}
-              disabled={disabled}
+              disabled={disabled || isBalanceLoading || isOpenPending}
               onClick={onOpenPosition}
             />
           </div>

--- a/src/stories/template/PoolDetail/hooks.ts
+++ b/src/stories/template/PoolDetail/hooks.ts
@@ -1,12 +1,14 @@
 import { isNil } from 'ramda';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
+import { useChromaticClient } from '~/hooks/useChromaticClient';
 import { useAppSelector } from '~/store';
 import { selectedLpSelector } from '~/store/selector';
 import { copyText } from '~/utils/clipboard';
 
 export const usePoolDetail = () => {
   const selectedLp = useAppSelector(selectedLpSelector);
+  const { client } = useChromaticClient();
   const lpTitle = useMemo(() => {
     if (isNil(selectedLp)) {
       return;
@@ -39,6 +41,26 @@ export const usePoolDetail = () => {
     }
   };
 
+  const onCLPRegister = useCallback(async () => {
+    if (isNil(selectedLp)) {
+      return;
+    }
+    const isAdded = await client.walletClient?.watchAsset({
+      type: 'ERC20',
+      options: {
+        address: selectedLp.address,
+        symbol: selectedLp.clpSymbol,
+        decimals: selectedLp.clpDecimals,
+      },
+    });
+
+    if (isAdded) {
+      toast('New CLP token was registered.');
+    } else {
+      toast.error('Failed to register.');
+    }
+  }, [client.walletClient, selectedLp]);
+
   return {
     lpTitle,
     lpName: selectedLp?.name,
@@ -46,5 +68,6 @@ export const usePoolDetail = () => {
     lpAddress: selectedLp?.address,
     // marketDescription: selectedLp?.market.description,
     onCopyAddress,
+    onCLPRegister,
   };
 };

--- a/src/stories/template/PoolDetail/index.tsx
+++ b/src/stories/template/PoolDetail/index.tsx
@@ -1,10 +1,8 @@
-import { AddressWithButton } from '~/stories/atom/AddressWithButton';
-import { Outlink } from '~/stories/atom/Outlink';
-import { Button } from '~/stories/atom/Button';
-import { MetamaskIcon } from '~/assets/icons/SocialIcon';
-import { PlusIcon } from '~/assets/icons/Icon';
 import { isNil } from 'ramda';
+import { PlusIcon } from '~/assets/icons/Icon';
 import { useBlockExplorer } from '~/hooks/useBlockExplorer';
+import { AddressWithButton } from '~/stories/atom/AddressWithButton';
+import { Button } from '~/stories/atom/Button';
 import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { trimAddress } from '~/utils/address';
 import { usePoolDetail } from './hooks';
@@ -12,7 +10,7 @@ import { usePoolDetail } from './hooks';
 export interface PoolDetailProps {}
 
 export const PoolDetail = (props: PoolDetailProps) => {
-  const { lpTitle, lpName, lpTag, lpAddress, onCopyAddress } = usePoolDetail();
+  const { lpTitle, lpName, lpTag, lpAddress, onCopyAddress, onCLPRegister } = usePoolDetail();
   const blockExplorer = useBlockExplorer({
     path: 'address',
     address: lpAddress,
@@ -33,6 +31,9 @@ export const PoolDetail = (props: PoolDetailProps) => {
               css="translucent"
               gap="1"
               size="xs"
+              onClick={() => {
+                onCLPRegister();
+              }}
             />
           </div>
         </div>

--- a/src/stories/template/TradeManagementV3/hooks.ts
+++ b/src/stories/template/TradeManagementV3/hooks.ts
@@ -20,9 +20,19 @@ import { abs, divPreserved, formatDecimals } from '~/utils/number';
 
 export function useTradeManagementV3() {
   const { currentMarket } = useMarket();
-  const { positions, isLoading, fetchCurrentPositions } = usePositions();
-  const { historyData, isLoading: isHistoryLoading, onFetchNextHistory } = useTradeHistory();
-  const { tradesData, isLoading: isTradeLogsLoading, onFetchNextTrade } = useTradeLogs();
+  const { positions, isLoading, fetchPositions, fetchCurrentPositions } = usePositions();
+  const {
+    historyData,
+    isLoading: isHistoryLoading,
+    onFetchNextHistory,
+    refreshTradeHistory,
+  } = useTradeHistory();
+  const {
+    tradesData,
+    isLoading: isTradeLogsLoading,
+    onFetchNextTrade,
+    refreshTradeLogs,
+  } = useTradeLogs();
   const { initialBlockNumber } = useInitialBlockNumber();
   const { fetchBalances } = useChromaticAccount();
   const previousOracle = usePrevious(currentMarket?.oracleValue.version);
@@ -60,6 +70,10 @@ export function useTradeManagementV3() {
 
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const tabRef = useRef<number>(0);
+  const onLoadTabRef = useCallback((index: number) => {
+    tabRef.current = index;
+  }, []);
   const [isGuideVisible, setGuideVisible] = useState(false);
 
   const historyBottomRef = useRef<HTMLDivElement | null>(null);
@@ -214,6 +228,22 @@ export function useTradeManagementV3() {
   const onLoadTradesRef = useCallback((element: HTMLDivElement | null) => {
     tradeBottomRef.current = element;
   }, []);
+  const onRefreshList = useCallback(async () => {
+    switch (tabRef.current) {
+      case 0: {
+        await fetchPositions();
+        break;
+      }
+      case 1: {
+        await refreshTradeHistory();
+        break;
+      }
+      case 2: {
+        await refreshTradeLogs();
+        break;
+      }
+    }
+  }, [fetchPositions, refreshTradeHistory, refreshTradeLogs]);
 
   return {
     openButtonRef,
@@ -241,5 +271,7 @@ export function useTradeManagementV3() {
     onFetchNextHistory,
     onLoadHistoryRef,
     onLoadTradesRef,
+    onLoadTabRef,
+    onRefreshList,
   };
 }

--- a/src/stories/template/TradeManagementV3/index.tsx
+++ b/src/stories/template/TradeManagementV3/index.tsx
@@ -6,11 +6,11 @@ import './style.css';
 import { Listbox, Tab } from '@headlessui/react';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { Button } from '~/stories/atom/Button';
+import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { HistoryItem } from '~/stories/molecule/HistoryItem';
 import { PositionItemV2 } from '~/stories/molecule/PositionItemV2';
 import { TradesItem } from '~/stories/molecule/TradesItem';
-import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 
 import { usePositionFilter } from '~/hooks/usePositionFilter';
 import { FilterOption } from '~/typings/position';
@@ -37,6 +37,8 @@ export const TradeManagementV3 = () => {
     onLoadTradesRef,
 
     formattedElapsed,
+    onLoadTabRef,
+    onRefreshList,
   } = useTradeManagementV3();
 
   // TODO: PERCENTAGE
@@ -46,7 +48,11 @@ export const TradeManagementV3 = () => {
   return (
     <div className="TradeManagementV3">
       <div className="w-full wrapper-tabs">
-        <Tab.Group>
+        <Tab.Group
+          onChange={(index) => {
+            onLoadTabRef(index);
+          }}
+        >
           <div className="flex flex-col w-full">
             <div className="flex items-end border-b border-gray-light">
               <Tab.List className="flex-none font-semibold tabs-list tabs-line tabs-left">
@@ -83,7 +89,13 @@ export const TradeManagementV3 = () => {
                       </SkeletonElement>
                     </p>
                   </div>
-                  <Button iconOnly={<ArrowPathIcon />} css="unstyled" />
+                  <Button
+                    iconOnly={<ArrowPathIcon />}
+                    css="unstyled"
+                    onClick={() => {
+                      onRefreshList();
+                    }}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Description

- Check required data are loaded at routes
  - `/trade`, Positions should be loaded
  - `/pool`, Chromatic LPs, and LP receipts should be loaded

- Fetch positions with reduced requests
  - Fetch positions with multiple markets at once
  - Mutate existed positions

- Open positions
  - Reduce trade fee when clicking `max` button

- Refresh positions, trade history, or logs when clicking refresh buttons
- Update positions when selecting other markets
- Register CLP tokens when clicking a button
- Disable buttons when opening a new position