### PR TITLE
fix: Frontend QA & Airdrop Modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,12 @@ import { WagmiConfig, createConfig, createStorage } from 'wagmi';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import '~/App.css';
 import '~/bigint';
-import { router } from '~/routes';
-import { store } from '~/store/index';
 import { chains, publicClient, webSocketPublicClient } from '~/configs/wagmiClient';
 import { ChromaticProvider } from '~/contexts/ChromaticClient';
 import { subscribePythFeed } from '~/lib/pyth/subscribe';
+import { router } from '~/routes';
+import { store } from '~/store/index';
+import { showCautionToast } from './stories/atom/Toast';
 
 const config = createConfig({
   autoConnect: true,
@@ -28,6 +29,16 @@ function App() {
         action && action();
       });
     };
+  }, []);
+
+  useEffect(() => {
+    showCautionToast({
+      title: 'Introducing Chromatic Testnet',
+      titleClass: 'text-chrm',
+      message:
+        'During the testnet, contract updates may reset deposited assets, open positions, and liquidity data in your account.',
+      showLogo: true,
+    });
   }, []);
 
   return (

--- a/src/hooks/airdrops/useAirdropSync.ts
+++ b/src/hooks/airdrops/useAirdropSync.ts
@@ -1,4 +1,6 @@
+import { AxiosError } from 'axios';
 import { isNotNil } from 'ramda';
+import { useCallback, useState } from 'react';
 import useSWRMutation from 'swr/mutation';
 import { useAccount } from 'wagmi';
 import { airdropClient } from '~/apis/airdrop';
@@ -7,6 +9,12 @@ import { checkAllProps } from '~/utils';
 
 export const useAirdropSync = () => {
   const { address } = useAccount();
+  const [syncState, setSyncState] = useState({
+    isFailed: false,
+    isZealyConnected: true,
+    receivedXp: 0,
+    convertedCredit: 0,
+  });
   const fetchKey = {
     address,
     key: 'fetchAirdropSync',
@@ -14,22 +22,74 @@ export const useAirdropSync = () => {
   const { trigger: synchronize, isMutating } = useSWRMutation(
     checkAllProps(fetchKey) ? fetchKey : undefined,
     async ({ address }) => {
-      const response = await airdropClient.post('/airdrop/assets/sync-zealy', {
-        address,
-      });
-      if (isNotNil((response.data as SyncZealy).synced_count)) {
-        
-      } else {
-        if (response.data.message === 'WALLET_NOT_LINKED_TO_ZEALY') {
-          //TODO show popup
+      try {
+        const response = await airdropClient.post('/airdrop/assets/sync-zealy', {
+          address,
+        });
+        if (isNotNil((response.data as SyncZealy).synced_count)) {
+          setSyncState((state) => ({
+            ...state,
+            isLoaded: true,
+            isZealyConnected: true,
+          }));
+          return;
         }
-        throw new Error('Error found in sync');
+        if (response.data.message === 'WALLET_NOT_LINKED_TO_ZEALY') {
+          setSyncState((state) => ({
+            ...state,
+            isFailed: true,
+            isLoaded: true,
+          }));
+        } else {
+          setSyncState((state) => ({
+            ...state,
+            isFailed: true,
+            isLoaded: true,
+          }));
+          throw new Error('Error found in sync');
+        }
+      } catch (error) {
+        if (!(error instanceof AxiosError)) {
+          console.error(error);
+          return;
+        }
+        const { response } = error;
+        if (response?.data.message === 'WALLET_NOT_LINKED_TO_ZEALY') {
+          // FIXME
+        }
+        setSyncState((state) => ({
+          ...state,
+          isFailed: true,
+          isLoaded: true,
+        }));
       }
     }
   );
 
+  const onModalClose = useCallback(() => {
+    setSyncState({ isFailed: false, isZealyConnected: false, receivedXp: 0, convertedCredit: 0 });
+  }, []);
+
+  const onZealyConnect = useCallback(() => {
+    const anchor = document.createElement('a');
+    anchor.href = 'https://zealy.io/cw/_/settings/linked-accounts' satisfies `https://${string}`;
+    anchor.target = '_blank';
+    anchor.rel = 'noreferrer';
+    anchor.click();
+    onModalClose();
+  }, [onModalClose]);
+
+  // FIXME: Need to implement
+  const onCreditConvert = useCallback(() => {
+    onModalClose();
+  }, [onModalClose]);
+
   return {
-    synchronize,
+    syncState,
     isMutating,
+    synchronize,
+    onZealyConnect,
+    onCreditConvert,
+    onModalClose,
   };
 };

--- a/src/hooks/airdrops/useAirdropSync.ts
+++ b/src/hooks/airdrops/useAirdropSync.ts
@@ -1,5 +1,4 @@
 import { AxiosError } from 'axios';
-import { isNotNil } from 'ramda';
 import { useCallback, useState } from 'react';
 import useSWRMutation from 'swr/mutation';
 import { useAccount } from 'wagmi';
@@ -25,11 +24,23 @@ export const useAirdropSync = () => {
         address,
       });
       const { synced_xp: xp } = response.data as SyncZealy;
-      if (isNotNil(xp)) {
+      if (xp > 0) {
         return {
           credit: xp,
           xp,
           isZealyConnected: true,
+          title: 'Successfully converted!',
+          content: 'Your Zealy XP has been successfully converted to\nChromatic airdrop Credit.',
+        };
+      }
+      if (xp === 0) {
+        // TODO: Should check the content more valuable.
+        return {
+          credit: xp,
+          xp,
+          isZealyConnected: true,
+          title: 'No changes',
+          content: 'Your Zealy XP would be same as current credit.',
         };
       }
     } catch (error) {

--- a/src/hooks/useCLPPerformace.ts
+++ b/src/hooks/useCLPPerformace.ts
@@ -25,9 +25,9 @@ export const useCLPPerformance = () => {
 
     const performaces = periods.reduce((performances, period) => {
       const profit = response.lp_performances_by_pk?.[`rate_${period}`];
-      performances[period] = numberFormat(profit ?? '0', {
-        minDigits: 2,
-        maxDigits: 2,
+      performances[period] = numberFormat(profit * 100 ?? '0', {
+        minDigits: 3,
+        maxDigits: 3,
         roundingMode: 'trunc',
         type: 'string',
         useGrouping: true,

--- a/src/hooks/useChromaticLp.ts
+++ b/src/hooks/useChromaticLp.ts
@@ -258,6 +258,7 @@ export const useChromaticLp = () => {
     },
     {
       keepPreviousData: false,
+      refreshInterval: 1000 * 60,
     }
   );
 

--- a/src/hooks/useLiquidityPool.ts
+++ b/src/hooks/useLiquidityPool.ts
@@ -102,14 +102,11 @@ export const useLiquidityPool = (marketAddress?: Address, tokenAddress?: Address
     isAssetReady && isReady && checkAllProps(fetchKeyData) && fetchKeyData,
     async ({ marketAddress, tokenAddress }) => {
       const lensApi = client.lens();
-
-      debugger;
-
       const pool = await getLiquidityPool(lensApi, marketAddress, tokenAddress);
 
       return pool;
     },
-    { keepPreviousData: false, dedupingInterval: 8000 }
+    { keepPreviousData: false, refreshInterval: 1000 * 60 }
   );
 
   const [longTotalMaxLiquidity, longTotalUnusedLiquidity] = useMemo(() => {

--- a/src/hooks/usePositionFilter.ts
+++ b/src/hooks/usePositionFilter.ts
@@ -9,10 +9,8 @@ import { useSettlementToken } from './useSettlementToken';
 
 export const usePositionFilter = () => {
   const filterOption = useAppSelector((state) => state.position.filterOption);
-  const { state: storedFilterOption, setState: setStoredFilterOption } = useLocalStorage(
-    'app:position',
-    'ALL' as FilterOption
-  );
+  const { state: storedFilterOption, setState: setStoredFilterOption } =
+    useLocalStorage<FilterOption>('app:position', 'MARKET_ONLY');
 
   const { currentToken } = useSettlementToken();
   const { currentMarket } = useMarket();

--- a/src/hooks/usePositionFilterLocal.ts
+++ b/src/hooks/usePositionFilterLocal.ts
@@ -9,7 +9,7 @@ export const usePositionFilterLocal = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   const { state: storedFilterOption, setState: setStoredFilterOption } = useLocalStorage(
     'app:position',
-    'ALL' as FilterOption
+    'MARKET_ONLY' as FilterOption
   );
 
   const dispatch = useAppDispatch();

--- a/src/pages/airdrop/index.tsx
+++ b/src/pages/airdrop/index.tsx
@@ -190,7 +190,7 @@ function Airdrop() {
                                   className=""
                                   size="lg"
                                   css="underlined"
-                                  href="https://zealy.io/cw/_/settings/profile"
+                                  href="https://zealy.io/cw/_/settings/linked-accounts"
                                 />
                               </div>
                             </div>

--- a/src/pages/airdrop/index.tsx
+++ b/src/pages/airdrop/index.tsx
@@ -1,42 +1,43 @@
 import { Tab } from '@headlessui/react';
-import { ArrowUpTrayIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAccount, useConnect } from 'wagmi';
+
 import { OutlinkIcon } from '~/assets/icons/Icon';
-import { Loading } from '~/stories/atom/Loading';
 import { ChromaticLogo } from '~/assets/icons/Logo';
 import RandomboxImage from '~/assets/images/airdrop_randombox.png';
-import GalxeIcon from '~/assets/images/galxe.png';
 import ZealyIcon from '~/assets/images/zealy.png';
+import { useAirdropAssets } from '~/hooks/airdrops/useAirdropAssets';
+import { useAirdropLeaderBoard } from '~/hooks/airdrops/useAirdropLeaderBoard';
+import { useAirdropSync } from '~/hooks/airdrops/useAirdropSync';
+import { useMarketLocal } from '~/hooks/useMarketLocal';
+import { useTokenLocal } from '~/hooks/useTokenLocal';
+import { useAppSelector } from '~/store';
+
 import { BlurText } from '~/stories/atom/BlurText';
 import { Button } from '~/stories/atom/Button';
-import { Outlink } from '~/stories/atom/Outlink';
+import { Loading } from '~/stories/atom/Loading';
 import '~/stories/atom/Tabs/style.css';
 import { Toast } from '~/stories/atom/Toast';
 import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 import { ChainModal } from '~/stories/container/ChainModal';
-import { AirdropActivity, ArrowInfo } from '~/stories/template/AirdropActivity';
+import { AirdropActivity } from '~/stories/template/AirdropActivity';
 import { AirdropBoard } from '~/stories/template/AirdropBoard';
 import { AirdropHistory } from '~/stories/template/AirdropHistory';
 import { AirdropStamp } from '~/stories/template/AirdropStamp';
+import { AirdropZealyConnectModal } from '~/stories/template/AirdropZealyConnectModal';
+import { AirdropZealyConvertModal } from '~/stories/template/AirdropZealyConvertModal';
 import { Footer } from '~/stories/template/Footer';
 import { HeaderV3 } from '~/stories/template/HeaderV3';
 import { Modal } from '~/stories/template/Modal';
-
-import { useMarketLocal } from '~/hooks/useMarketLocal';
-import { useTokenLocal } from '~/hooks/useTokenLocal';
-
-import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { useAccount, useConnect } from 'wagmi';
-import { useAirdropAssets } from '~/hooks/airdrops/useAirdropAssets';
-import { useAirdropLeaderBoard } from '~/hooks/airdrops/useAirdropLeaderBoard';
-import { useAirdropSync } from '~/hooks/airdrops/useAirdropSync';
-import { useAppSelector } from '~/store';
 import { numberFormat } from '~/utils/number';
 import './style.css';
 
 function Airdrop() {
   const { airdropAssets } = useAirdropAssets();
-  const { synchronize } = useAirdropSync();
+  const { syncState, isMutating, synchronize, onZealyConnect, onCreditConvert, onModalClose } =
+    useAirdropSync();
   const { refreshAssets } = useAirdropAssets();
   const { filterLabels, labelMap, selectedIndex } = useAppSelector((state) => state.airdrop);
   const { metadata } = useAirdropLeaderBoard({
@@ -64,6 +65,18 @@ function Airdrop() {
   return (
     <>
       <div className="page-container bg-gradient-chrm">
+        <AirdropZealyConnectModal
+          isOpen={syncState.isFailed}
+          onClick={onZealyConnect}
+          onClose={onModalClose}
+        />
+        <AirdropZealyConvertModal
+          isOpen={syncState.isZealyConnected}
+          xp={syncState.receivedXp}
+          credit={syncState.convertedCredit}
+          onClick={onCreditConvert}
+          onClose={onModalClose}
+        />
         <HeaderV3 />
         {_isConnected ? (
           <>
@@ -142,7 +155,7 @@ function Airdrop() {
                                 <Button
                                   label="Convert XP to Credit"
                                   // TODO: show icon when loading
-                                  iconLeft={<Loading />}
+                                  iconLeft={isMutating ? <Loading /> : null}
                                   css="active"
                                   size="sm"
                                   className="!text-lg"

--- a/src/pages/airdrop/index.tsx
+++ b/src/pages/airdrop/index.tsx
@@ -36,7 +36,7 @@ import './style.css';
 
 function Airdrop() {
   const { airdropAssets } = useAirdropAssets();
-  const { syncState, isMutating, synchronize, onZealyConnect, onCreditConvert, onModalClose } =
+  const { syncState, isMutating, isOpened, synchronize, onZealyConnect, onModalClose } =
     useAirdropSync();
   const { refreshAssets } = useAirdropAssets();
   const { filterLabels, labelMap, selectedIndex } = useAppSelector((state) => state.airdrop);
@@ -66,15 +66,15 @@ function Airdrop() {
     <>
       <div className="page-container bg-gradient-chrm">
         <AirdropZealyConnectModal
-          isOpen={syncState.isFailed}
+          isOpen={Boolean(isOpened && syncState?.isFailed)}
           onClick={onZealyConnect}
           onClose={onModalClose}
         />
         <AirdropZealyConvertModal
-          isOpen={syncState.isZealyConnected}
-          xp={syncState.receivedXp}
-          credit={syncState.convertedCredit}
-          onClick={onCreditConvert}
+          isOpen={Boolean(isOpened && syncState?.isZealyConnected)}
+          xp={syncState?.xp}
+          credit={syncState?.credit}
+          onClick={onModalClose}
           onClose={onModalClose}
         />
         <HeaderV3 />
@@ -156,6 +156,7 @@ function Airdrop() {
                                   label="Convert XP to Credit"
                                   // TODO: show icon when loading
                                   iconLeft={isMutating ? <Loading /> : null}
+                                  disabled={isMutating}
                                   css="active"
                                   size="sm"
                                   className="!text-lg"

--- a/src/pages/airdrop/index.tsx
+++ b/src/pages/airdrop/index.tsx
@@ -72,8 +72,7 @@ function Airdrop() {
         />
         <AirdropZealyConvertModal
           isOpen={Boolean(isOpened && syncState?.isZealyConnected)}
-          xp={syncState?.xp}
-          credit={syncState?.credit}
+          syncData={syncState}
           onClick={onModalClose}
           onClose={onModalClose}
         />

--- a/src/pages/airdrop/index.tsx
+++ b/src/pages/airdrop/index.tsx
@@ -190,7 +190,7 @@ function Airdrop() {
                                   className=""
                                   size="lg"
                                   css="underlined"
-                                  href=""
+                                  href="https://zealy.io/cw/_/settings/profile"
                                 />
                               </div>
                             </div>

--- a/src/stories/atom/Toast/index.tsx
+++ b/src/stories/atom/Toast/index.tsx
@@ -1,5 +1,6 @@
 import { ToastContainer, toast } from 'react-toastify';
 import { ChromaticRowLogo } from '~/assets/icons/Logo';
+
 import 'react-toastify/dist/ReactToastify.css';
 import './style.css';
 
@@ -70,4 +71,12 @@ const Msg = (props: MsgProps) => {
       )}
     </div>
   );
+};
+
+export const showCautionToast = (props: MsgProps) => {
+  toast(<Msg {...props} />, {
+    autoClose: false,
+    closeButton: true,
+    closeOnClick: false,
+  });
 };

--- a/src/stories/template/AirdropActivity/index.tsx
+++ b/src/stories/template/AirdropActivity/index.tsx
@@ -47,7 +47,7 @@ export const AirdropActivity = (props: AirdropActivityProps) => {
             </div>
             <div className="flex flex-col gap-2 text-right">
               <h4 className="text-[28px]">{airdropAssets?.booster}</h4>
-              <p className="text-primary-light">17 Booster Chances</p>
+              <p className="text-primary-light">{airdropAssets?.booster} Booster Chances</p>
             </div>
           </div>
           <p className="pt-5">

--- a/src/stories/template/AirdropZealyConvertModal/index.tsx
+++ b/src/stories/template/AirdropZealyConvertModal/index.tsx
@@ -1,20 +1,22 @@
 import '~/stories/template/Modal/style.css';
 
 import { Dialog } from '@headlessui/react';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { CoinStackIcon } from '~/assets/icons/Icon';
+import ZealyIcon from '~/assets/images/zealy.png';
 import { Button } from '~/stories/atom/Button';
 import { ModalCloseButton } from '~/stories/atom/ModalCloseButton';
-import { CoinStackIcon } from '~/assets/icons/Icon';
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
-import ZealyIcon from '~/assets/images/zealy.png';
 
 export interface AirdropZealyConvertModalProps {
   isOpen: boolean;
+  xp: number;
+  credit: number;
   onClick: () => unknown;
   onClose: () => unknown;
 }
 
 export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
-  const { isOpen, onClick, onClose } = props;
+  const { isOpen, xp, credit, onClick, onClose } = props;
 
   return (
     <Dialog open={isOpen} onClose={onClose}>
@@ -34,12 +36,12 @@ export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
               <div className="flex justify-center gap-5 mt-10 mb-2">
                 <div className="flex flex-col items-center justify-center w-1/3 gap-2">
                   <img src={ZealyIcon} alt="zealy" className="h-6" />
-                  <h4 className="ml-2 text-xl">350XP</h4>
+                  <h4 className="text-xl">{xp} XP</h4>
                 </div>
                 <ArrowRightIcon className="w-5" />
                 <div className="flex flex-col items-center justify-center w-1/3 gap-2">
                   <CoinStackIcon className="w-7" />
-                  <h4 className="ml-1 text-xl capitalize text-chrm">350 Credits</h4>
+                  <h4 className="text-xl capitalize text-chrm">{credit} Credits</h4>
                 </div>
               </div>
             </article>

--- a/src/stories/template/AirdropZealyConvertModal/index.tsx
+++ b/src/stories/template/AirdropZealyConvertModal/index.tsx
@@ -9,14 +9,19 @@ import { ModalCloseButton } from '~/stories/atom/ModalCloseButton';
 
 export interface AirdropZealyConvertModalProps {
   isOpen: boolean;
-  xp?: number;
-  credit?: number;
+  syncData?: {
+    xp?: number;
+    credit?: number;
+    title?: string;
+    content?: string;
+  };
   onClick: () => unknown;
   onClose: () => unknown;
 }
 
 export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
-  const { isOpen, xp = 0, credit = 0, onClick, onClose } = props;
+  const { isOpen, syncData, onClick, onClose } = props;
+  const { xp = 0, credit = 0, title, content } = syncData ?? {};
 
   return (
     <Dialog open={isOpen} onClose={onClose}>
@@ -28,11 +33,8 @@ export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
           </Dialog.Title>
           <Dialog.Description className="gap-5 modal-content">
             <article className="text-center">
-              <h2 className="text-4xl">Successfully converted!</h2>
-              <p className="mt-3 mb-6 text-primary-light">
-                Your Zealy XP has been successfully converted to <br />
-                Chromatic airdrop Credit.
-              </p>
+              <h2 className="text-4xl">{title}</h2>
+              <p className="mt-3 mb-6 text-primary-light whitespace-pre-line">{content}</p>
               <div className="flex justify-center gap-5 mt-10 mb-2">
                 <div className="flex flex-col items-center justify-center w-1/3 gap-2">
                   <img src={ZealyIcon} alt="zealy" className="h-6" />

--- a/src/stories/template/AirdropZealyConvertModal/index.tsx
+++ b/src/stories/template/AirdropZealyConvertModal/index.tsx
@@ -9,14 +9,14 @@ import { ModalCloseButton } from '~/stories/atom/ModalCloseButton';
 
 export interface AirdropZealyConvertModalProps {
   isOpen: boolean;
-  xp: number;
-  credit: number;
+  xp?: number;
+  credit?: number;
   onClick: () => unknown;
   onClose: () => unknown;
 }
 
 export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
-  const { isOpen, xp, credit, onClick, onClose } = props;
+  const { isOpen, xp = 0, credit = 0, onClick, onClose } = props;
 
   return (
     <Dialog open={isOpen} onClose={onClose}>

--- a/src/stories/template/AirdropZealyConvertModal/stories.ts
+++ b/src/stories/template/AirdropZealyConvertModal/stories.ts
@@ -15,6 +15,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     isOpen: true,
+    credit: 350,
+    xp: 350,
     onClick() {},
     onClose() {},
   },

--- a/src/stories/template/AirdropZealyConvertModal/stories.ts
+++ b/src/stories/template/AirdropZealyConvertModal/stories.ts
@@ -15,8 +15,12 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     isOpen: true,
-    credit: 350,
-    xp: 350,
+    syncData: {
+      credit: 350,
+      xp: 350,
+      title: 'Successfully converted!',
+      content: 'Your Zealy XP has been successfully converted to\nChromatic airdrop Credit.',
+    },
     onClick() {},
     onClose() {},
   },


### PR DESCRIPTION
## Description

- Reduce requests to fetch markets
- Show percentage value of CLP performances
- Interval to fetch huge data
  - Liquidity Bins
  - Chromatic LP

- Show positions when entered trade page the first time
- Show caution toast when entered frontend
- Refactor to parse stream data to json

- Airdrop
  - Sync my wallet address to Zealy account
  - Show modal to connect each accounts
    - Navigate to Zealy page when `connect` button
    
  - Show modal to inform credits user would receive
  - Close modals to click `close` button

## Related Issues

fixes #601 