### PR TITLE
fix: Show profits & toasts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { ChromaticProvider } from '~/contexts/ChromaticClient';
 import { subscribePythFeed } from '~/lib/pyth/subscribe';
 import { router } from '~/routes';
 import { store } from '~/store/index';
-import { showCautionToast } from './stories/atom/Toast';
 
 const config = createConfig({
   autoConnect: true,
@@ -29,16 +28,6 @@ function App() {
         action && action();
       });
     };
-  }, []);
-
-  useEffect(() => {
-    showCautionToast({
-      title: 'Introducing Chromatic Testnet',
-      titleClass: 'text-chrm',
-      message:
-        'During the testnet, contract updates may reset deposited assets, open positions, and liquidity data in your account.',
-      showLogo: true,
-    });
   }, []);
 
   return (

--- a/src/hooks/useCLPPerformace.ts
+++ b/src/hooks/useCLPPerformace.ts
@@ -35,7 +35,7 @@ export const useCLPPerformance = () => {
           const profit = response.lp_performances_by_pk?.[`pnl_${period}`];
           const rate = response.lp_performances_by_pk?.[`rate_${period}`];
 
-          const parsedProfit = isNotNil(profit) ? parseUnits(profit, currentToken.decimals) : 0n;
+          const parsedProfit = isNotNil(profit) ? BigInt(profit) : 0n;
           const parsedRate = isNotNil(rate) ? parseUnits(rate, currentToken.decimals) * 100n : 0n;
 
           profits[period] = parsedProfit;

--- a/src/hooks/useTimeDifferences.ts
+++ b/src/hooks/useTimeDifferences.ts
@@ -1,8 +1,8 @@
 export const useTimeDifferences = () => {
   const offset = new Date().getTimezoneOffset();
 
-  const unit = offset < 0 ? 'am' : 'pm';
-  const prefix = offset < 0 ? '+' : '-';
+  const unit = offset <= 0 ? 'am' : 'pm';
+  const prefix = offset <= 0 ? '+' : '-';
   const hours = Math.abs(Math.floor(offset / 60));
   let formattedHours = hours;
   if (prefix === '-') {
@@ -15,7 +15,7 @@ export const useTimeDifferences = () => {
   }
 
   const formattedMinutes = minutes.toString().padStart(2, '0');
-  console.log(formattedHours);
+
   return {
     hours,
     minutes,

--- a/src/pages/poolV3/index.tsx
+++ b/src/pages/poolV3/index.tsx
@@ -1,6 +1,6 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { isNil, isNotNil } from 'ramda';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { PlusIcon } from '~/assets/icons/Icon';
 import useBackgroundGradient from '~/hooks/useBackgroundGradient';
@@ -14,7 +14,7 @@ import { Avatar } from '~/stories/atom/Avatar';
 import { Button } from '~/stories/atom/Button';
 import { SkeletonElement } from '~/stories/atom/SkeletonElement';
 import { Tag } from '~/stories/atom/Tag';
-import { Toast } from '~/stories/atom/Toast';
+import { Toast, showCautionToast } from '~/stories/atom/Toast';
 import { ChainModal } from '~/stories/container/ChainModal';
 import { MarketSelectV3 } from '~/stories/molecule/MarketSelectV3';
 import { BookmarkBoardV3 } from '~/stories/template/BookmarkBoardV3';
@@ -90,6 +90,16 @@ const PoolV3 = () => {
       toast.error('Failed to register.');
     }
   }, [client.walletClient, selectedLp]);
+
+  useEffect(() => {
+    showCautionToast({
+      title: 'Introducing Chromatic Testnet',
+      titleClass: 'text-chrm',
+      message:
+        'During the testnet, contract updates may reset deposited assets, open positions, and liquidity data in your account.',
+      showLogo: true,
+    });
+  }, []);
 
   return (
     <>

--- a/src/pages/tradeV3/index.tsx
+++ b/src/pages/tradeV3/index.tsx
@@ -1,7 +1,7 @@
 import useBackgroundGradient from '~/hooks/useBackgroundGradient';
 import { useMarketLocal } from '~/hooks/useMarketLocal';
 import { useTokenLocal } from '~/hooks/useTokenLocal';
-import { Toast } from '~/stories/atom/Toast';
+import { Toast, showCautionToast } from '~/stories/atom/Toast';
 import { ChainModal } from '~/stories/container/ChainModal';
 import { MarketSelectV3 } from '~/stories/molecule/MarketSelectV3';
 import { BookmarkBoardV3 } from '~/stories/template/BookmarkBoardV3';
@@ -11,6 +11,7 @@ import { TradeChartPanel } from '~/stories/template/TradeChartPanel';
 import { TradeManagementV3 } from '~/stories/template/TradeManagementV3';
 import { TradePanelV3 } from '~/stories/template/TradePanelV3';
 
+import { useEffect } from 'react';
 import { usePositionFilterLocal } from '~/hooks/usePositionFilterLocal';
 import './style.css';
 
@@ -21,6 +22,16 @@ function TradeV3() {
 
   const { beforeCondition, afterCondition, toggleConditions, onLoadBackgroundRef } =
     useBackgroundGradient();
+
+  useEffect(() => {
+    showCautionToast({
+      title: 'Introducing Chromatic Testnet',
+      titleClass: 'text-chrm',
+      message:
+        'During the testnet, contract updates may reset deposited assets, open positions, and liquidity data in your account.',
+      showLogo: true,
+    });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Description

- Show profits of CLP with proper decimals from GraphQL responses
- Show the formatted timezone offset of London (UTC+0)
- Show caution toasts when users are on trade or pool page