### PR TITLE
dia/fix-detail

### DIFF
--- a/src/stories/molecule/TradeContentV3/index.tsx
+++ b/src/stories/molecule/TradeContentV3/index.tsx
@@ -162,7 +162,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
               <Input
                 // size="sm"
                 unit="x"
-                className="w-20 ml-auto"
+                className="w-24 ml-auto "
                 value={leverage}
                 placeholder={leveragePlaceholder}
                 autoCorrect
@@ -179,7 +179,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
               <div className="flex items-center gap-2">
                 <h4 className="text-left">Take Profit</h4>
               </div>
-              <div className="w-20">
+              <div className="w-24">
                 <Input
                   size="sm"
                   unit="%"
@@ -207,7 +207,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
               <div className="flex items-center gap-2">
                 <h4 className="text-left">Stop Loss</h4>
               </div>
-              <div className="w-20">
+              <div className="w-24">
                 <Input
                   size="sm"
                   unit="%"
@@ -271,7 +271,7 @@ export const TradeContentV3 = (props: TradeContentV3Props) => {
                   outLinkAbout="Next Oracle Round"
                 />
               </div>
-              <div className="w-20">
+              <div className="w-24">
                 <Input
                   size="xs"
                   unit="%"

--- a/src/stories/template/AirdropBoard/hooks.ts
+++ b/src/stories/template/AirdropBoard/hooks.ts
@@ -40,12 +40,25 @@ export const useAirdropBoard = () => {
     return sum.totalBooster < metadata.totalBooster || sum.totalCredit < metadata.totalCredit;
   }, [metadata, leaderboard, isLoading]);
 
+  const creditLabel = useMemo(() => {
+    const foundLabel = filterLabels.find((label) => selectedLabel === labelMap[label]);
+    switch (foundLabel) {
+      case 'All Time': {
+        return 'Credits (All Time)';
+      }
+      default: {
+        return 'Credits (1D)';
+      }
+    }
+  }, []);
+
   const onLabelChange = (nextIndex: number) => {
     dispatch(airdropAction.onLabelSwitch(nextIndex));
   };
 
   return {
     filterLabels,
+    creditLabel,
     labelMap,
     activeLabel: selectedLabel,
     leaderboard,

--- a/src/stories/template/AirdropBoard/hooks.ts
+++ b/src/stories/template/AirdropBoard/hooks.ts
@@ -50,7 +50,7 @@ export const useAirdropBoard = () => {
         return 'Credits (1D)';
       }
     }
-  }, []);
+  }, [filterLabels, labelMap, selectedLabel]);
 
   const onLabelChange = (nextIndex: number) => {
     dispatch(airdropAction.onLabelSwitch(nextIndex));

--- a/src/stories/template/AirdropBoard/index.tsx
+++ b/src/stories/template/AirdropBoard/index.tsx
@@ -9,6 +9,7 @@ import './style.css';
 export const AirdropBoard = () => {
   const {
     filterLabels,
+    creditLabel,
     labelMap,
     activeLabel,
     leaderboard,
@@ -42,14 +43,7 @@ export const AirdropBoard = () => {
                 <div className="td">Rank</div>
                 <div className="td">Name</div>
                 <div className="td">
-                  Credits (
-                  {filterLabels.map(
-                    (label, labelIndex) =>
-                      activeLabel === labelMap[label] && (
-                        <span key={labelIndex}>{label === 'All Time' ? 'All Time' : '1D'}</span>
-                      )
-                  )}
-                  )
+                  <span>{creditLabel}</span>
                 </div>
                 <div className="td">Boosters</div>
               </div>

--- a/src/stories/template/AirdropBoard/index.tsx
+++ b/src/stories/template/AirdropBoard/index.tsx
@@ -42,9 +42,7 @@ export const AirdropBoard = () => {
               <div className="tr">
                 <div className="td">Rank</div>
                 <div className="td">Name</div>
-                <div className="td">
-                  <span>{creditLabel}</span>
-                </div>
+                <div className="td">{creditLabel}</div>
                 <div className="td">Boosters</div>
               </div>
             </div>

--- a/src/stories/template/AirdropBoard/index.tsx
+++ b/src/stories/template/AirdropBoard/index.tsx
@@ -41,8 +41,16 @@ export const AirdropBoard = () => {
               <div className="tr">
                 <div className="td">Rank</div>
                 <div className="td">Name</div>
-                <div className="td">Credits (1D)</div>
-                <div className="td">Credits (All Time)</div>
+                <div className="td">
+                  Credits (
+                  {filterLabels.map(
+                    (label, labelIndex) =>
+                      activeLabel === labelMap[label] && (
+                        <span key={labelIndex}>{label === 'All Time' ? 'All Time' : '1D'}</span>
+                      )
+                  )}
+                  )
+                </div>
                 <div className="td">Boosters</div>
               </div>
             </div>
@@ -67,14 +75,6 @@ export const AirdropBoard = () => {
                       width={40}
                     >
                       {boardItem.address}
-                    </SkeletonElement>
-                  </div>
-                  <div className="td">
-                    <SkeletonElement
-                      // isLoading={isLoading}
-                      width={40}
-                    >
-                      {boardItem.credit}
                     </SkeletonElement>
                   </div>
                   <div className="td">


### PR DESCRIPTION
- fix airdrop > leader board > credit info (sheet no.24)
  - show "all time" credit info only when "all time" label is active.
  - show "1day" credit info when "today", "yesterday" label is active.
- update trade > input size