### PR TITLE
fix: Optimized updating oracles, positions, receipts

### DIFF
--- a/src/hooks/commons/useBookmarkOracles.ts
+++ b/src/hooks/commons/useBookmarkOracles.ts
@@ -1,0 +1,61 @@
+import { isNotNil } from 'ramda';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { MARKET_LOGOS } from '~/configs/token';
+import { Bookmark, Market } from '~/typings/market';
+import { checkAllProps } from '~/utils';
+import { useChromaticClient } from '../useChromaticClient';
+import { useError } from '../useError';
+import useLocalStorage from '../useLocalStorage';
+import { usePreviousOracles } from '../usePreviousOracles';
+import useMarketOracles from './useMarketOracles';
+
+const useBookmarkOracles = () => {
+  const { state: bookmarks } = useLocalStorage('app:bookmarks', [] as Bookmark[]);
+  const { isReady } = useChromaticClient();
+  const fetchKey = {
+    key: 'useBookmarkOracles',
+    bookmarks:
+      isNotNil(bookmarks) && bookmarks.length > 0
+        ? bookmarks.filter((bookmark) => isNotNil(bookmark.marketAddress))
+        : ('EMPTY' as const),
+  };
+
+  const { data: markets, error } = useSWR(
+    isReady && checkAllProps(fetchKey) && fetchKey,
+    async ({ bookmarks }) => {
+      if (bookmarks === 'EMPTY') {
+        return [];
+      }
+      return bookmarks.map((bookmark) => {
+        const { marketDescription, marketAddress, tokenAddress } = bookmark;
+        const [prefix] = marketDescription.split(/\s*\/\s*/) as [string, string];
+        const image = MARKET_LOGOS[prefix];
+        return {
+          address: marketAddress,
+          description: marketDescription,
+          image,
+          tokenAddress,
+        } satisfies Market;
+      });
+    }
+  );
+
+  const { marketOracles, mutateMarketOracles } = useMarketOracles({ markets });
+  const { previousOracles } = usePreviousOracles({ markets });
+  const bookmarkOracles = useMemo(() => {
+    return bookmarks?.map((bookmark, index) => {
+      return {
+        ...bookmark,
+        currentOracle: marketOracles?.[bookmark.marketAddress],
+        previousOracle: previousOracles?.[bookmark.marketAddress],
+      };
+    });
+  }, [bookmarks, marketOracles, previousOracles]);
+
+  useError({ error });
+
+  return { bookmarkOracles, markets, mutateMarketOracles };
+};
+
+export default useBookmarkOracles;

--- a/src/hooks/commons/useMarketOracle.ts
+++ b/src/hooks/commons/useMarketOracle.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import useSWR from 'swr';
 import { Market } from '~/typings/market';
 import { checkAllProps } from '~/utils';
@@ -19,6 +20,7 @@ const useMarketOracle = (props: UseMarketOracle) => {
     data: currentOracle,
     isLoading,
     error,
+    mutate,
   } = useSWR(
     checkAllProps(fetchKey) ? fetchKey : undefined,
     async ({ market }) => {
@@ -28,13 +30,17 @@ const useMarketOracle = (props: UseMarketOracle) => {
       return currentOracle;
     },
     {
-      refreshInterval: 1000 * 30,
+      refreshInterval: 0,
     }
   );
 
   useError({ error });
 
-  return { currentOracle, isLoading };
+  const refreshMarketOracle = useCallback(async () => {
+    await mutate();
+  }, [mutate]);
+
+  return { currentOracle, isLoading, refreshMarketOracle };
 };
 
 export default useMarketOracle;

--- a/src/hooks/commons/useMarkets.ts
+++ b/src/hooks/commons/useMarkets.ts
@@ -56,6 +56,9 @@ const useMarkets = () => {
           description: `${prefix}/${suffix}`,
         };
       });
+    },
+    {
+      refreshInterval: 0,
     }
   );
 

--- a/src/hooks/commons/useOracleListener.ts
+++ b/src/hooks/commons/useOracleListener.ts
@@ -1,0 +1,142 @@
+import { watchContractEvent } from '@wagmi/core';
+import { isNil, isNotNil } from 'ramda';
+import { useEffect } from 'react';
+import useSWR from 'swr';
+import { parseAbiItem } from 'viem';
+import { Market } from '~/typings/market';
+import { promiseIfFulfilled } from '~/utils/promise';
+import { useChromaticClient } from '../useChromaticClient';
+import { useError } from '../useError';
+
+const aggregatorAbi = parseAbiItem('function aggregator() external view returns (address)');
+const answerUpdatedAbi = parseAbiItem(
+  'event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)'
+);
+
+interface UseOracleListener<M extends Market[] | Market> {
+  market?: M extends Market ? Market : undefined;
+  markets?: M extends Market[] ? Market[] : undefined;
+  onUpdate?: (market: Market) => unknown;
+}
+
+const useOracleListener = <M extends Market[] | Market>(props: UseOracleListener<M>) => {
+  const { market, markets, onUpdate } = props;
+  const { isReady, client } = useChromaticClient();
+  const fetchKey = {
+    key: 'useOracleListener',
+    market,
+    markets,
+  };
+  const {
+    data: response,
+    error,
+    isLoading,
+  } = useSWR(
+    isReady ? fetchKey : undefined,
+    async ({ market, markets }) => {
+      if (isNotNil(market)) {
+        const providerAddress = await client.market().oracleProvider(market.address);
+        const aggregator = await client.publicClient?.readContract({
+          abi: [aggregatorAbi],
+          address: providerAddress,
+          functionName: 'aggregator',
+        });
+        if (isNil(aggregator)) {
+          return;
+        }
+        const chainlinkAddress = await client.publicClient?.readContract({
+          abi: [aggregatorAbi],
+          address: aggregator,
+          functionName: 'aggregator',
+        });
+        return chainlinkAddress;
+      } else if (isNotNil(markets)) {
+        const providerAddresses = await promiseIfFulfilled(
+          markets.map(async (market) => {
+            const providerAddress = await client.market().oracleProvider(market.address);
+            return providerAddress;
+          })
+        );
+        const aggregators = await promiseIfFulfilled(
+          providerAddresses.map((address) => {
+            if (isNil(address)) {
+              return undefined;
+            }
+            return client.publicClient?.readContract({
+              abi: [aggregatorAbi],
+              address,
+              functionName: 'aggregator',
+            });
+          })
+        );
+        const chainlinkAddresses = await promiseIfFulfilled(
+          aggregators.map((address) => {
+            if (isNil(address)) {
+              return undefined;
+            }
+            return client.publicClient?.readContract({
+              abi: [aggregatorAbi],
+              address,
+              functionName: 'aggregator',
+            });
+          })
+        );
+        return chainlinkAddresses;
+      }
+    },
+    {
+      refreshInterval: 0,
+    }
+  );
+
+  useError({ error });
+  useEffect(() => {
+    if (isNil(market) && isNil(markets)) {
+      return;
+    }
+    if (isNil(onUpdate)) {
+      return;
+    }
+    if (isNil(response)) {
+      return;
+    }
+    if (response instanceof Array && isNotNil(markets)) {
+      const chainlinkAddresses = response;
+      const unwatches = chainlinkAddresses.map((chainlinkAddress, index) => {
+        const unwatch = watchContractEvent(
+          {
+            abi: [answerUpdatedAbi],
+            address: chainlinkAddress,
+            eventName: 'AnswerUpdated',
+          },
+          (logs) => {
+            onUpdate?.(markets[index]);
+          }
+        );
+        return unwatch;
+      });
+
+      return () => {
+        unwatches.forEach((unwatch) => unwatch());
+      };
+    } else if (!(response instanceof Array) && isNotNil(market)) {
+      const chainlinkAddress = response;
+      const unwatch = watchContractEvent(
+        {
+          abi: [answerUpdatedAbi],
+          address: chainlinkAddress,
+          eventName: 'AnswerUpdated',
+        },
+        (logs) => {
+          onUpdate?.(market);
+        }
+      );
+
+      return () => {
+        unwatch();
+      };
+    }
+  }, [market, markets, onUpdate, response]);
+};
+
+export default useOracleListener;

--- a/src/hooks/updates/useBookmarksUpdate.ts
+++ b/src/hooks/updates/useBookmarksUpdate.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { Market } from '~/typings/market';
+import useBookmarkOracles from '../commons/useBookmarkOracles';
+import useOracleListener from '../commons/useOracleListener';
+
+const useBookmarksUpdate = () => {
+  const { markets, mutateMarketOracles } = useBookmarkOracles();
+  const onUpdate = useCallback(
+    (market: Market) => {
+      mutateMarketOracles(market.address);
+    },
+    [mutateMarketOracles]
+  );
+
+  useOracleListener({
+    markets,
+    onUpdate,
+  });
+};
+
+export default useBookmarksUpdate;

--- a/src/hooks/updates/useLpReceiptsUpdate.ts
+++ b/src/hooks/updates/useLpReceiptsUpdate.ts
@@ -1,0 +1,51 @@
+import { iChromaticLpABI } from '@chromatic-protocol/liquidity-provider-sdk/contracts';
+import { watchContractEvent } from '@wagmi/core';
+import { isNil } from 'ramda';
+import { useEffect, useMemo } from 'react';
+import { useAppSelector } from '~/store';
+import { selectedLpSelector } from '~/store/selector';
+
+const receiptAbi = iChromaticLpABI.filter((abi) => abi.type === 'event');
+const receiptEvents = [
+  'AddLiquidity',
+  'AddLiquiditySettled',
+  'RemoveLiquidity',
+  'RemoveLiquiditySettled',
+] as const;
+
+// TODO: Can listen all events from the abi of lp receipts, with one event name only.
+const eventName: (typeof receiptEvents)[number] = 'AddLiquidity';
+
+interface UseLpReceiptsUpdate {
+  callbacks?: (() => unknown)[];
+}
+
+const useLpReceiptsUpdate = (props: UseLpReceiptsUpdate) => {
+  const { callbacks } = props;
+  const selectedLp = useAppSelector(selectedLpSelector);
+  const lpAddress = useMemo(() => {
+    return selectedLp?.address;
+  }, [selectedLp]);
+
+  useEffect(() => {
+    if (isNil(lpAddress)) {
+      return;
+    }
+    const unwatch = watchContractEvent(
+      {
+        abi: receiptAbi,
+        eventName,
+        address: lpAddress,
+      },
+      (logs) => {
+        callbacks?.forEach((callback) => callback());
+      }
+    );
+
+    return () => {
+      unwatch();
+    };
+  }, [lpAddress, callbacks]);
+};
+
+export default useLpReceiptsUpdate;

--- a/src/hooks/updates/useLpReceiptsUpdate.ts
+++ b/src/hooks/updates/useLpReceiptsUpdate.ts
@@ -2,6 +2,7 @@ import { iChromaticLpABI } from '@chromatic-protocol/liquidity-provider-sdk/cont
 import { watchContractEvent } from '@wagmi/core';
 import { isNil } from 'ramda';
 import { useEffect, useMemo } from 'react';
+import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
 import { selectedLpSelector } from '~/store/selector';
 
@@ -23,6 +24,7 @@ interface UseLpReceiptsUpdate {
 const useLpReceiptsUpdate = (props: UseLpReceiptsUpdate) => {
   const { callbacks } = props;
   const selectedLp = useAppSelector(selectedLpSelector);
+  const { address } = useAccount();
   const lpAddress = useMemo(() => {
     return selectedLp?.address;
   }, [selectedLp]);
@@ -38,14 +40,17 @@ const useLpReceiptsUpdate = (props: UseLpReceiptsUpdate) => {
         address: lpAddress,
       },
       (logs) => {
-        callbacks?.forEach((callback) => callback());
+        const myLogs = logs.filter((log) => log.args.recipient === address);
+        if (myLogs.length !== 0) {
+          callbacks?.forEach((callback) => callback());
+        }
       }
     );
 
     return () => {
       unwatch();
     };
-  }, [lpAddress, callbacks]);
+  }, [callbacks, lpAddress, address]);
 };
 
 export default useLpReceiptsUpdate;

--- a/src/hooks/updates/useMarketsUpdate.ts
+++ b/src/hooks/updates/useMarketsUpdate.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { Market } from '~/typings/market';
+import useMarketOracle from '../commons/useMarketOracle';
+import useMarketOracles from '../commons/useMarketOracles';
+import useMarkets from '../commons/useMarkets';
+import useOracleListener from '../commons/useOracleListener';
+
+const useMarketsUpdate = () => {
+  const { markets, currentMarket } = useMarkets();
+  const { mutateMarketOracles } = useMarketOracles({ markets });
+  const { refreshMarketOracle } = useMarketOracle({ market: currentMarket });
+  const onUpdate = useCallback(
+    (market: Market) => {
+      mutateMarketOracles(market.address);
+    },
+    [mutateMarketOracles]
+  );
+
+  useOracleListener({
+    markets,
+    onUpdate,
+  });
+
+  useOracleListener({
+    market: currentMarket,
+    onUpdate: useCallback(() => {
+      refreshMarketOracle();
+    }, [refreshMarketOracle]),
+  });
+};
+
+export default useMarketsUpdate;

--- a/src/hooks/updates/usePositionsUpdate.ts
+++ b/src/hooks/updates/usePositionsUpdate.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { Market } from '~/typings/market';
+import useFilteredMarkets from '../commons/useFilteredMarkets';
+import useMarketOracle from '../commons/useMarketOracle';
+import useOracleListener from '../commons/useOracleListener';
+import { usePositions } from '../usePositions';
+
+const usePositionsUpdate = () => {
+  const { markets, currentMarket } = useFilteredMarkets();
+  const { fetchCurrentPositions } = usePositions();
+  const { refreshMarketOracle } = useMarketOracle({ market: currentMarket });
+  const onUpdate = useCallback(
+    (market: Market) => {
+      if (market.address === currentMarket?.address) {
+        refreshMarketOracle();
+      }
+      fetchCurrentPositions(market.address);
+    },
+    [currentMarket?.address, refreshMarketOracle, fetchCurrentPositions]
+  );
+
+  useOracleListener({
+    markets,
+    onUpdate,
+  });
+};
+
+export default usePositionsUpdate;

--- a/src/hooks/useAddChromaticLp.ts
+++ b/src/hooks/useAddChromaticLp.ts
@@ -1,17 +1,21 @@
-import { isNil } from 'ramda';
+import { isNil, isNotNil } from 'ramda';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { useAppSelector } from '~/store';
 import { selectedLpSelector } from '~/store/selector';
-import { dispatchLpEvent, dispatchLpReceiptEvent } from '~/typings/events';
+import { dispatchLpEvent } from '~/typings/events';
 import useMarkets from './commons/useMarkets';
 import { useChromaticClient } from './useChromaticClient';
+import { useLpReceiptCount } from './useLpReceiptCount';
+import { useLpReceipts } from './useLpReceipts';
 
 export const useAddChromaticLp = () => {
   const { client, lpClient, isReady } = useChromaticClient();
   const { currentMarket } = useMarkets();
+  const { onMutateLpReceipts } = useLpReceipts();
+  const { onMutateLpReceiptCount } = useLpReceiptCount();
   const { address } = useAccount();
   const selectedLp = useAppSelector(selectedLpSelector);
   const [isAddPending, setIsAddPending] = useState(false);
@@ -36,9 +40,12 @@ export const useAddChromaticLp = () => {
         throw new Error('Settlement token approval failed.');
       }
       const receipt = await lp.addLiquidity(selectedLp.address, parsedAmount, address);
-
+      if (isNotNil(receipt)) {
+        const timestamp = Math.floor(Date.now() / 1000);
+        onMutateLpReceiptCount('minting');
+        await onMutateLpReceipts(receipt, selectedLp.address, 'minting', BigInt(timestamp));
+      }
       dispatchLpEvent();
-      dispatchLpReceiptEvent();
       toast('Add process started.');
       setIsAddPending(false);
     } catch (error) {

--- a/src/hooks/useChromaticAccount.ts
+++ b/src/hooks/useChromaticAccount.ts
@@ -36,23 +36,29 @@ export const useChromaticAccount = () => {
     error,
     mutate: fetchAddress,
     isLoading: isAccountAddressLoading,
-  } = useSWR(isReady && checkAllProps(fetchKey) && fetchKey, async ({ address }) => {
-    try {
-      const accountApi = client.account();
-      const accountAddress = await accountApi.getAccount();
+  } = useSWR(
+    isReady && checkAllProps(fetchKey) && fetchKey,
+    async ({ address }) => {
+      try {
+        const accountApi = client.account();
+        const accountAddress = await accountApi.getAccount();
 
-      if (isNil(accountAddress) || accountAddress === ADDRESS_ZERO) {
+        if (isNil(accountAddress) || accountAddress === ADDRESS_ZERO) {
+          dispatch(setAccountStatus(ACCOUNT_STATUS.NONE));
+        } else {
+          dispatch(setAccountStatus(ACCOUNT_STATUS.COMPLETED));
+        }
+        return accountAddress;
+      } catch (error) {
         dispatch(setAccountStatus(ACCOUNT_STATUS.NONE));
-      } else {
-        dispatch(setAccountStatus(ACCOUNT_STATUS.COMPLETED));
+        logger.error(error);
+        return ADDRESS_ZERO as Address;
       }
-      return accountAddress;
-    } catch (error) {
-      dispatch(setAccountStatus(ACCOUNT_STATUS.NONE));
-      logger.error(error);
-      return ADDRESS_ZERO as Address;
+    },
+    {
+      refreshInterval: 0,
     }
-  });
+  );
 
   const { tokens } = useSettlementToken();
   const accountBalanceFetchKey = useMemo(

--- a/src/hooks/useCreateAccount.ts
+++ b/src/hooks/useCreateAccount.ts
@@ -27,7 +27,7 @@ export const useCreateAccount = () => {
       await accountApi.createAccount();
 
       const newAccount = await accountApi.getAccount();
-      await fetchAddress(newAccount);
+      await fetchAddress(newAccount, { revalidate: false });
 
       dispatch(setAccountStatus(ACCOUNT_STATUS.COMPLETING));
     } catch (error) {

--- a/src/hooks/useLpReceiptCount.ts
+++ b/src/hooks/useLpReceiptCount.ts
@@ -4,6 +4,7 @@ import { useAccount } from 'wagmi';
 import { checkAllProps } from '~/utils';
 import { useError } from './useError';
 
+import { isNil } from 'ramda';
 import { lpGraphSdk } from '~/lib/graphql';
 import { useAppSelector } from '~/store';
 import { selectedLpSelector } from '~/store/selector';
@@ -63,7 +64,7 @@ export const useLpReceiptCount = () => {
     },
     {
       // TODO: Find proper interval seconds
-      refreshInterval: 1000 * 6,
+      refreshInterval: 0,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
       revalidateOnFocus: false,
@@ -78,9 +79,25 @@ export const useLpReceiptCount = () => {
     mutate();
   }, [mutate]);
 
+  const onMutateLpReceiptCount = useCallback(
+    (action: 'minting' | 'burning') => {
+      if (isNil(counts)) {
+        return;
+      }
+      const nextCounts = {
+        ...counts,
+        [action]: counts[action] + 1,
+        inProgress: counts['inProgress'] + 1,
+      };
+      mutate(nextCounts, { revalidate: false });
+    },
+    [counts, mutate]
+  );
+
   return {
     counts,
     isCountLoading,
     onRefreshLpReceiptCount,
+    onMutateLpReceiptCount,
   };
 };

--- a/src/hooks/useLpReceipts.ts
+++ b/src/hooks/useLpReceipts.ts
@@ -17,7 +17,7 @@ import {
   Sdk,
 } from '~/lib/graphql/sdk/lp';
 import { useAppDispatch, useAppSelector } from '~/store';
-import { selectedLpSelector } from '~/store/selector';
+import { receiptActionSelector, selectedLpSelector } from '~/store/selector';
 import { LpReceipt, LpToken, ReceiptAction } from '~/typings/lp';
 import { Market, Token } from '~/typings/market';
 import { checkAllProps } from '~/utils';
@@ -209,16 +209,13 @@ const mapToDetailedReceipts = async (args: MapToDetailedReceiptsArgs) => {
   return detailedReceipts;
 };
 
-type UseLpReceipts = {
-  currentAction: ReceiptAction;
-};
-
-export const useLpReceipts = (props: UseLpReceipts) => {
+export const useLpReceipts = () => {
   const { isReady, lpClient, client } = useChromaticClient();
   const { address } = useAccount();
   const { currentMarket } = useMarkets();
   const { tokens } = useSettlementToken();
   const selectedLp = useAppSelector(selectedLpSelector);
+  const receiptAction = useAppSelector(receiptActionSelector);
   const dispatch = useAppDispatch();
   const clpMeta = useMemo(() => {
     if (isNil(selectedLp)) {
@@ -234,8 +231,6 @@ export const useLpReceipts = (props: UseLpReceipts) => {
     } satisfies LpToken;
     return metadata;
   }, [selectedLp]);
-
-  const { currentAction } = props;
 
   const {
     data: receiptsData,
@@ -261,7 +256,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
         tokens,
         currentMarket: trimMarket(currentMarket),
         clpMeta,
-        currentAction,
+        receiptAction,
         pageIndex,
       };
       if (!checkAllProps(fetchKey)) {
@@ -274,7 +269,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
       currentMarket,
       tokens,
       clpMeta,
-      currentAction,
+      receiptAction,
       toBlockTimestamp,
       pageIndex,
     }) => {
@@ -288,7 +283,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
       let receipts: LpReceipt[] = [];
 
       let currentReceipts = [] as LpReceipt[];
-      if (currentAction !== 'burning') {
+      if (receiptAction !== 'burning') {
         const addMap = await getAddReceipts(lpGraphSdk, {
           count,
           walletAddress,
@@ -297,7 +292,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
         });
         currentReceipts = currentReceipts.concat(Array.from(addMap.values()));
       }
-      if (currentAction !== 'minting') {
+      if (receiptAction !== 'minting') {
         const removeMap = await getRemoveReceipts(lpGraphSdk, {
           count,
           walletAddress,
@@ -324,7 +319,7 @@ export const useLpReceipts = (props: UseLpReceipts) => {
         client,
         receipts,
         currentMarket,
-        currentAction,
+        currentAction: receiptAction,
         settlementToken,
         clpMeta,
       });

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -146,7 +146,7 @@ export const usePositions = () => {
     },
     {
       // TODO: Find proper interval seconds
-      refreshInterval: 1000 * 60,
+      refreshInterval: 0,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
       revalidateOnFocus: false,
@@ -157,11 +157,7 @@ export const usePositions = () => {
 
   const fetchCurrentPositions = useCallback(
     async (marketAddress: Address) => {
-      if (isLoading) {
-        return;
-      }
-      if (isNil(positions) || isNil(accountAddress) || isNil(accountAddress)) return positions;
-
+      if (isNil(positions) || isNil(accountAddress)) return positions;
       const filteredPositions = positions
         ?.filter((p) => !!p)
         .filter((position) => position.marketAddress !== marketAddress);
@@ -170,6 +166,7 @@ export const usePositions = () => {
       const positionApi = client.position();
       const marketApi = client.market();
       const foundMarket = markets?.find((market) => market.address === marketAddress);
+
       if (isNil(foundMarket)) {
         return;
       }
@@ -185,7 +182,7 @@ export const usePositions = () => {
       mergedPositions.sort((previous, next) => (previous.id < next.id ? 1 : -1));
       await fetchPositions<Position[]>(mergedPositions, { revalidate: false });
     },
-    [client, isLoading, markets, positions, accountAddress, fetchPositions]
+    [client, markets, positions, accountAddress, fetchPositions]
   );
 
   useError({

--- a/src/hooks/useSettlementToken.ts
+++ b/src/hooks/useSettlementToken.ts
@@ -28,25 +28,31 @@ export const useSettlementToken = () => {
     error,
     mutate: fetchTokens,
     isLoading: isTokenLoading,
-  } = useSWR<Token[]>(isReady && fetchKey, async () => {
-    const marketFactoryApi = client.marketFactory();
+  } = useSWR<Token[]>(
+    isReady && fetchKey,
+    async () => {
+      const marketFactoryApi = client.marketFactory();
 
-    const registeredSettlementTokens = await marketFactoryApi.registeredSettlementTokens();
-    const settlementTokens = await PromiseOnlySuccess(
-      registeredSettlementTokens.map(async (token) => {
-        const minimumMargin = await marketFactoryApi
-          .contracts()
-          .marketFactory.read.getMinimumMargin([token.address]);
-        return {
-          ...token,
-          minimumMargin,
-          image: MARKET_LOGOS[token.name],
-        } as Token;
-      })
-    );
+      const registeredSettlementTokens = await marketFactoryApi.registeredSettlementTokens();
+      const settlementTokens = await PromiseOnlySuccess(
+        registeredSettlementTokens.map(async (token) => {
+          const minimumMargin = await marketFactoryApi
+            .contracts()
+            .marketFactory.read.getMinimumMargin([token.address]);
+          return {
+            ...token,
+            minimumMargin,
+            image: MARKET_LOGOS[token.name],
+          } as Token;
+        })
+      );
 
-    return settlementTokens;
-  });
+      return settlementTokens;
+    },
+    {
+      refreshInterval: 0,
+    }
+  );
 
   useError({ error });
 

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import useBookmarksUpdate from '~/hooks/updates/useBookmarksUpdate';
+import useMarketsUpdate from '~/hooks/updates/useMarketsUpdate';
 import useBackgroundGradient from '~/hooks/useBackgroundGradient';
 import { subscribePythFeed } from '~/lib/pyth/subscribe';
 import { Toast, showCautionToast } from '~/stories/atom/Toast';
@@ -11,6 +13,7 @@ import { HeaderV3 } from '~/stories/template/HeaderV3';
 export const ChromaticLayout = () => {
   const location = useLocation();
   const [isToastLoaded, setIsToastLoaded] = useState(false);
+  useMarketsUpdate();
   useEffect(() => {
     if (isToastLoaded) {
       return;
@@ -65,6 +68,7 @@ export const ChromaticLayout = () => {
 
 export const GradientLayout = () => {
   const { onLoadBackgroundRef } = useBackgroundGradient();
+  useBookmarksUpdate();
   useEffect(() => {
     const unsubscriber = subscribePythFeed();
     return () => {

--- a/src/pages/poolV3/index.tsx
+++ b/src/pages/poolV3/index.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { PlusIcon } from '~/assets/icons/Icon';
 import useMarketLocal from '~/hooks/commons/useMarketLocal';
+import useLpReceiptsUpdate from '~/hooks/updates/useLpReceiptsUpdate';
 import { useChromaticClient } from '~/hooks/useChromaticClient';
 import { useLpLocal } from '~/hooks/useLpLocal';
 import { useTokenLocal } from '~/hooks/useTokenLocal';
@@ -22,6 +23,7 @@ import { PoolMenuV3 } from '~/stories/template/PoolMenuV3';
 import { PoolPanelV2 } from '~/stories/template/PoolPanelV2';
 import { PoolPerformance } from '~/stories/template/PoolPerformance';
 import { PoolStat } from '~/stories/template/PoolStat';
+import { dispatchLpReceiptEvent } from '~/typings/events';
 import { formatDecimals } from '~/utils/number';
 
 const PoolV3 = () => {
@@ -84,6 +86,12 @@ const PoolV3 = () => {
       toast.error('Failed to register.');
     }
   }, [client.walletClient, selectedLp]);
+
+  useLpReceiptsUpdate({
+    callbacks: useMemo(() => {
+      return [dispatchLpReceiptEvent];
+    }, []),
+  });
 
   return (
     <>

--- a/src/pages/tradeV3/index.tsx
+++ b/src/pages/tradeV3/index.tsx
@@ -1,4 +1,5 @@
 import useMarketLocal from '~/hooks/commons/useMarketLocal';
+import usePositionsUpdate from '~/hooks/updates/usePositionsUpdate';
 import { usePositionFilterLocal } from '~/hooks/usePositionFilterLocal';
 import { useTokenLocal } from '~/hooks/useTokenLocal';
 import { MarketSelectV3 } from '~/stories/molecule/MarketSelectV3';
@@ -11,6 +12,7 @@ function TradeV3() {
   useTokenLocal();
   useMarketLocal();
   usePositionFilterLocal();
+  usePositionsUpdate();
 
   return (
     <>

--- a/src/store/reducer/lp/index.ts
+++ b/src/store/reducer/lp/index.ts
@@ -1,13 +1,15 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { ChromaticLp } from '~/typings/lp';
+import { ChromaticLp, ReceiptAction } from '~/typings/lp';
 
 interface LpState {
   selectedLp?: ChromaticLp;
+  receiptAction: ReceiptAction;
 }
 
 const initialState: LpState = {
   selectedLp: undefined,
+  receiptAction: 'all',
 };
 
 export const lpSlice = createSlice({
@@ -19,6 +21,9 @@ export const lpSlice = createSlice({
     },
     onLpUnselect: (state) => {
       state.selectedLp = undefined;
+    },
+    onActionSelect: (state, action: PayloadAction<ReceiptAction>) => {
+      state.receiptAction = action.payload;
     },
   },
 });

--- a/src/store/selector/index.ts
+++ b/src/store/selector/index.ts
@@ -6,6 +6,11 @@ export const selectedLpSelector = createSelector(
   (lp) => lp.selectedLp
 );
 
+export const receiptActionSelector = createSelector(
+  (state: RootState) => state.lp,
+  (lp) => lp.receiptAction
+);
+
 export const selectedTokenSelector = createSelector(
   (state: RootState) => state.token,
   (token) => token.selectedToken

--- a/src/stories/molecule/AnalyticsChart/index.tsx
+++ b/src/stories/molecule/AnalyticsChart/index.tsx
@@ -1,17 +1,16 @@
+import { isEmpty } from 'ramda';
 import { ReactNode, useState } from 'react';
 import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
   Line,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-  ComposedChart,
-  Area,
 } from 'recharts';
-import { isEmpty } from 'ramda';
-import LOADING from '~/assets/images/loading.png';
 
 import { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart';
 
@@ -103,8 +102,12 @@ export function AnalyticsChart({ data, map, x }: AnalyticsChartProps) {
           <div className="p-3">
             <p className="font-semibold text-primary">{date}</p>
             <div className="flex flex-col gap-1 mt-2 text-sm font-semibold text-primary-lighter">
-              {payload.map(({ name, color, value }) => (
-                <p style={{ color: color }} className="text-sm">
+              {payload.map(({ name, color, value }, index) => (
+                <p
+                  style={{ color: color }}
+                  className="text-sm"
+                  key={`${name}:${color}:${value}:${index}`}
+                >
                   {map[name].name}: {value}
                 </p>
               ))}

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -1,5 +1,6 @@
 import { isNil, isNotNil } from 'ramda';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import useMarkets from '~/hooks/commons/useMarkets';
 import { useChromaticLp } from '~/hooks/useChromaticLp';
 import { useLastOracle } from '~/hooks/useLastOracle';
 import useLocalStorage from '~/hooks/useLocalStorage';
@@ -16,7 +17,31 @@ export const usePoolProgressV2 = () => {
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const ref = useRef<HTMLDivElement>(null);
   const { fetchTokenBalances } = useTokenBalances();
-  const { formattedElapsed } = useLastOracle();
+  const { currentMarket } = useMarkets();
+  const { formattedElapsed } = useLastOracle({
+    market: currentMarket,
+    format: ({ type, value }) => {
+      switch (type) {
+        case 'hour': {
+          return `${value}h`;
+        }
+        case 'minute': {
+          return `${value}m`;
+        }
+        case 'second': {
+          return `${value}s`;
+        }
+        case 'literal': {
+          return ' ';
+        }
+        case 'dayPeriod': {
+          return '';
+        }
+        default:
+          return value;
+      }
+    },
+  });
   const receiptAction = useAppSelector(receiptActionSelector);
   const dispatch = useAppDispatch();
   const {

--- a/src/stories/molecule/PoolProgressV2/hooks.tsx
+++ b/src/stories/molecule/PoolProgressV2/hooks.tsx
@@ -1,11 +1,14 @@
 import { isNil, isNotNil } from 'ramda';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useChromaticLp } from '~/hooks/useChromaticLp';
 import { useLastOracle } from '~/hooks/useLastOracle';
 import useLocalStorage from '~/hooks/useLocalStorage';
 import { useLpReceiptCount } from '~/hooks/useLpReceiptCount';
 import { useLpReceipts } from '~/hooks/useLpReceipts';
 import { useTokenBalances } from '~/hooks/useTokenBalance';
+import { useAppDispatch, useAppSelector } from '~/store';
+import { lpAction } from '~/store/reducer/lp';
+import { receiptActionSelector } from '~/store/selector';
 import { LP_EVENT, LP_RECEIPT_EVENT } from '~/typings/events';
 import { LpReceipt, ReceiptAction } from '~/typings/lp';
 
@@ -14,15 +17,14 @@ export const usePoolProgressV2 = () => {
   const ref = useRef<HTMLDivElement>(null);
   const { fetchTokenBalances } = useTokenBalances();
   const { formattedElapsed } = useLastOracle();
-  const [receiptAction, setReceiptAction] = useState<ReceiptAction>('all');
+  const receiptAction = useAppSelector(receiptActionSelector);
+  const dispatch = useAppDispatch();
   const {
     receiptsData = [],
     isReceiptsLoading,
     onFetchNextLpReceipts,
     onRefreshLpReceipts,
-  } = useLpReceipts({
-    currentAction: receiptAction,
-  });
+  } = useLpReceipts();
   const { refreshChromaticLp } = useChromaticLp();
   const {
     counts = {
@@ -75,15 +77,15 @@ export const usePoolProgressV2 = () => {
   const onActionChange = (tabIndex: number) => {
     switch (tabIndex) {
       case 0: {
-        setReceiptAction('all');
+        dispatch(lpAction.onActionSelect('all'));
         break;
       }
       case 1: {
-        setReceiptAction('minting');
+        dispatch(lpAction.onActionSelect('minting'));
         break;
       }
       case 2: {
-        setReceiptAction('burning');
+        dispatch(lpAction.onActionSelect('burning'));
         break;
       }
     }

--- a/src/stories/template/BookmarkBoard/hooks.ts
+++ b/src/stories/template/BookmarkBoard/hooks.ts
@@ -3,15 +3,15 @@ import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { formatUnits } from 'viem';
 import { ORACLE_PROVIDER_DECIMALS } from '~/configs/decimals';
+import useBookmarkOracles from '~/hooks/commons/useBookmarkOracles';
 import useMarkets from '~/hooks/commons/useMarkets';
-import { useBookmarkOracles } from '~/hooks/useBookmarkOracles';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
 import { Bookmark } from '~/typings/market';
 import { numberFormat } from '~/utils/number';
 import { compareOracles } from '~/utils/price';
 
 export const useBookmarkBoard = () => {
-  const { bookmarkOracles, markets, isBookmarkLoading } = useBookmarkOracles();
+  const { bookmarkOracles, markets } = useBookmarkOracles();
   const { tokens, onTokenSelect } = useSettlementToken();
   const { onMarketSelect } = useMarkets();
 
@@ -78,7 +78,6 @@ export const useBookmarkBoard = () => {
     bookmarks,
     bookmarkPrices,
     bookmarkClasses,
-    isBookmarkLoading,
     onBookmarkClick,
   };
 };

--- a/src/stories/template/BookmarkBoard/index.tsx
+++ b/src/stories/template/BookmarkBoard/index.tsx
@@ -5,13 +5,7 @@ import './style.css';
 export interface BookmarkBoardProps {}
 
 export const BookmarkBoard = (props: BookmarkBoardProps) => {
-  const {
-    bookmarks = [],
-    bookmarkPrices,
-    bookmarkClasses,
-    isBookmarkLoading,
-    onBookmarkClick,
-  } = useBookmarkBoard();
+  const { bookmarks = [], bookmarkPrices, bookmarkClasses, onBookmarkClick } = useBookmarkBoard();
   return (
     <div className={`mb-2 BookmarkBoard ${bookmarks.length <= 0 ? 'hidden' : ''}`}>
       <div className="flex items-stretch h-6">

--- a/src/stories/template/BookmarkBoardV3/hooks.ts
+++ b/src/stories/template/BookmarkBoardV3/hooks.ts
@@ -3,15 +3,15 @@ import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { formatUnits } from 'viem';
 import { ORACLE_PROVIDER_DECIMALS } from '~/configs/decimals';
+import useBookmarkOracles from '~/hooks/commons/useBookmarkOracles';
 import useMarkets from '~/hooks/commons/useMarkets';
-import { useBookmarkOracles } from '~/hooks/useBookmarkOracles';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
 import { Bookmark, Market } from '~/typings/market';
 import { numberFormat } from '~/utils/number';
 import { compareOracles } from '~/utils/price';
 
 export const useBookmarkBoardV3 = () => {
-  const { bookmarkOracles, markets, isBookmarkLoading } = useBookmarkOracles();
+  const { bookmarkOracles, markets } = useBookmarkOracles();
   const { tokens, onTokenSelect } = useSettlementToken();
   const { onMarketSelect } = useMarkets();
 
@@ -78,7 +78,6 @@ export const useBookmarkBoardV3 = () => {
     bookmarks,
     bookmarkPrices,
     bookmarkClasses,
-    isBookmarkLoading,
     onBookmarkClick,
   };
 };

--- a/src/stories/template/BookmarkBoardV3/index.tsx
+++ b/src/stories/template/BookmarkBoardV3/index.tsx
@@ -6,13 +6,7 @@ import './style.css';
 export interface BookmarkBoardV3Props {}
 
 export const BookmarkBoardV3 = (props: BookmarkBoardV3Props) => {
-  const {
-    bookmarks = [],
-    bookmarkPrices,
-    bookmarkClasses,
-    isBookmarkLoading,
-    onBookmarkClick,
-  } = useBookmarkBoardV3();
+  const { bookmarks = [], bookmarkPrices, bookmarkClasses, onBookmarkClick } = useBookmarkBoardV3();
   return (
     <div className={`BookmarkBoardV3 ${bookmarks.length <= 0 ? 'hidden' : ''}`}>
       <div className="flex items-stretch h-6">


### PR DESCRIPTION
## Description

- Update market oracles when event are triggered from contracts
  - Receive `AnswerUpdated` events
  - Hooks to listen updates of each oracles

- Update positions when each oracles updated
  - Oracles of filtered markets
  - Show toasts when status of each positions updated

- Update LP receipts when following events are triggered
  - `AddLiquidity`, `AddLiquiditySettled`, `RemoveLiquidity`, `RemoveLiquiditySettled`
  - Mutate LP receipts after adding tokens to LP, or removing CLPs from LP

- Prevent unused network requests
  - Revalidating
  - Settlement tokens
  - After creating Chromatic accounts with user's wallet accounts.

## Related Issues

fixes #658 