### PR TITLE
feat: Show position close modal

### DIFF
--- a/src/hooks/useClaimPosition.ts
+++ b/src/hooks/useClaimPosition.ts
@@ -1,54 +1,61 @@
-import { isNil } from 'ramda';
+import { useMemo } from 'react';
 import { toast } from 'react-toastify';
+import useSWRMutation from 'swr/mutation';
 import { AppError } from '~/typings/error';
 import { Market } from '~/typings/market';
+import { Position } from '~/typings/position';
+import { checkAllProps } from '~/utils';
 import { errorLog } from '~/utils/log';
 import useMarketOracle from './commons/useMarketOracle';
 import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
+import { useError } from './useError';
 import { usePositions } from './usePositions';
 
 interface Props {
   market?: Market;
-  positionId: bigint;
+  position?: Position;
 }
 
 export function useClaimPosition(props: Props) {
-  const { market, positionId } = props;
-  const { client } = useChromaticClient();
+  const { market, position } = props;
+  const { client, isReady } = useChromaticClient();
   const { fetchBalances } = useChromaticAccount();
   const { currentOracle } = useMarketOracle({ market });
-  const { positions, fetchPositions, fetchCurrentPositions } = usePositions();
-  async function onClaimPosition() {
-    try {
-      if (isNil(market)) {
-        return AppError.reject('No markets', 'onClaimPosition');
-      }
-      const position = positions?.find(
-        (position) => position.marketAddress === market?.address && position.id === positionId
-      );
-      if (isNil(position)) {
-        errorLog('no positions');
-        toast('Positions are not selected.');
-        return AppError.reject('no positions', 'onClosePosition');
-      }
-      if ((currentOracle?.version || 0n) <= position.closeVersion) {
-        errorLog('the selected position is not closed');
-        toast('This position is not closed yet.');
-        return AppError.reject('the selected position is not closed', 'onClaimPosition');
-      }
-      const routerApi = client.router();
-      await routerApi.claimPosition(market?.address, position.id);
+  const { fetchCurrentPositions } = usePositions();
+  const mutationKey = useMemo(() => {
+    return { key: 'useClaimPosition', market, position, currentOracle };
+  }, [market, position, currentOracle]);
 
-      await fetchCurrentPositions(position.marketAddress);
-      await fetchBalances();
-      toast('The claiming process has been completed.');
-    } catch (error) {
-      toast.error('Transaction rejected.');
+  const {
+    trigger: onClaimPosition,
+    error,
+    isMutating,
+  } = useSWRMutation(
+    isReady && checkAllProps(mutationKey) ? mutationKey : undefined,
+    async ({ position, market, currentOracle }) => {
+      try {
+        if (currentOracle.version <= position.closeVersion) {
+          errorLog('the selected position is not closed');
+          toast('This position is not closed yet.');
+          return AppError.reject('the selected position is not closed', 'onClaimPosition');
+        }
+        const routerApi = client.router();
+        await routerApi.claimPosition(market?.address, position.id);
+
+        await fetchCurrentPositions(position.marketAddress);
+        await fetchBalances();
+        toast('The claiming process has been completed.');
+      } catch (error) {
+        toast.error('Transaction rejected.');
+      }
     }
-  }
+  );
+
+  useError({ error });
 
   return {
     onClaimPosition,
+    isMutating,
   };
 }

--- a/src/hooks/useClosePosition.ts
+++ b/src/hooks/useClosePosition.ts
@@ -1,49 +1,66 @@
 import { isNil } from 'ramda';
+import { useMemo } from 'react';
 import { toast } from 'react-toastify';
+import useSWRMutation from 'swr/mutation';
 import { Address } from 'wagmi';
 import { AppError } from '~/typings/error';
+import { checkAllProps } from '~/utils';
 import { errorLog } from '~/utils/log';
 import { useChromaticAccount } from './useChromaticAccount';
 import { useChromaticClient } from './useChromaticClient';
+import { useError } from './useError';
 import { usePositions } from './usePositions';
 
 interface Props {
-  marketAddress: Address;
-  positionId: bigint;
+  marketAddress?: Address;
+  positionId?: bigint;
 }
 
 function useClosePosition(props: Props) {
   const { marketAddress, positionId } = props;
-  const { client } = useChromaticClient();
-  const { positions, fetchPositions, fetchCurrentPositions } = usePositions();
+  const { client, isReady } = useChromaticClient();
+  const { fetchCurrentPositions } = usePositions();
   const { fetchBalances } = useChromaticAccount();
 
-  async function onClosePosition() {
-    const position = positions?.find(
-      (position) => position.marketAddress === marketAddress && position.id === positionId
-    );
-    if (isNil(position)) {
-      errorLog('no positions');
-      toast('Position is not selected.');
-      return AppError.reject('no positions', 'onClosePosition');
-    }
-    try {
-      const routerApi = client.router();
-      await routerApi?.closePosition(position.marketAddress, position.id);
+  const mutationKey = useMemo(() => {
+    return {
+      key: 'useClosePosition',
+      marketAddress,
+      positionId,
+    };
+  }, [marketAddress, positionId]);
 
-      await fetchCurrentPositions(position.marketAddress);
-      await fetchBalances();
-      toast('The closing process has started.');
-    } catch (error) {
-      errorLog(error);
-      toast.error('Transaction rejected.');
+  const {
+    trigger: onClosePosition,
+    isMutating,
+    error,
+  } = useSWRMutation(
+    isReady && checkAllProps(mutationKey) ? mutationKey : undefined,
+    async ({ marketAddress, positionId }) => {
+      if (isNil(positionId) || isNil(marketAddress)) {
+        return;
+      }
+      try {
+        const routerApi = client.router();
+        await routerApi?.closePosition(marketAddress, positionId);
 
-      return AppError.reject(error, 'onClosePosition');
+        await fetchCurrentPositions(marketAddress);
+        await fetchBalances();
+        toast('The closing process has started.');
+      } catch (error) {
+        errorLog(error);
+        toast.error('Transaction rejected.');
+
+        return AppError.reject(error, 'onClosePosition');
+      }
     }
-  }
+  );
+
+  useError({ error });
 
   return {
     onClosePosition,
+    isMutating,
   };
 }
 

--- a/src/stories/molecule/PositionItem/__mocks__/hooks.tsx
+++ b/src/stories/molecule/PositionItem/__mocks__/hooks.tsx
@@ -2,9 +2,9 @@ import { POSITION_STATUS } from '~/typings/position';
 
 import { PositionItemProps } from '..';
 
-interface usePositionItem extends PositionItemProps {}
+interface UsePositionItem extends PositionItemProps {}
 
-export function usePositionItem({ position }: usePositionItem) {
+export function usePositionItem({ position }: UsePositionItem) {
   const isOpening = position.status === POSITION_STATUS.OPENING;
   const isOpened = position.status === POSITION_STATUS.OPENED;
   const isClosing = position.status === POSITION_STATUS.CLOSING;

--- a/src/stories/molecule/PositionItem/hooks.tsx
+++ b/src/stories/molecule/PositionItem/hooks.tsx
@@ -120,7 +120,7 @@ export function usePositionItem({ position }: UsePositionItem) {
         hour12: false,
       }).format(new Date(Number(position.openTimestamp) * 1000)),
     };
-  }, [position, currentToken, markets]);
+  }, [position, currentToken, marketOracles]);
 
   const key = position.id.toString();
 
@@ -131,7 +131,7 @@ export function usePositionItem({ position }: UsePositionItem) {
     marketAddress: position.marketAddress,
   });
   const { onClaimPosition } = useClaimPosition({
-    positionId: position.id,
+    position,
     market: markets?.find((market) => market.address === position.marketAddress),
   });
 

--- a/src/stories/molecule/PositionItem/index.tsx
+++ b/src/stories/molecule/PositionItem/index.tsx
@@ -207,9 +207,11 @@ export function PositionItem(props: PositionItemProps) {
         <div className="w-[10%] min-w-[140px] flex flex-col items-center justify-center gap-2 pl-6 border-l">
           {/* Close / Claim USDC */}
           {(isOpened || isOpening) && (
-            <Button label="Close" css="light" size="sm" onClick={onClosePosition} />
+            <Button label="Close" css="light" size="sm" onClick={() => onClosePosition()} />
           )}
-          {isClosed && <Button label="Claim" css="active" size="sm" onClick={onClaimPosition} />}
+          {isClosed && (
+            <Button label="Claim" css="active" size="sm" onClick={() => onClaimPosition()} />
+          )}
           {isClosing && <Button label="Claim" css="default" size="sm" disabled={true} />}
         </div>
       </div>

--- a/src/stories/molecule/PositionItemV2/__mocks__/hooks.tsx
+++ b/src/stories/molecule/PositionItemV2/__mocks__/hooks.tsx
@@ -1,10 +1,10 @@
-import { POSITION_STATUS } from '~/typings/position';
+import { POSITION_STATUS, Position } from '~/typings/position';
 
 import { PositionItemV2Props } from '..';
 
-interface usePositionItemV2 extends PositionItemV2Props {}
+interface UsePositionItemV2 extends PositionItemV2Props {}
 
-export function usePositionItemV2({ position }: usePositionItemV2) {
+export function usePositionItemV2({ position }: UsePositionItemV2) {
   const isOpening = position.status === POSITION_STATUS.OPENING;
   const isOpened = position.status === POSITION_STATUS.OPENED;
   const isClosing = position.status === POSITION_STATUS.CLOSING;
@@ -34,5 +34,7 @@ export function usePositionItemV2({ position }: usePositionItemV2) {
     isOpened,
     isClosing,
     isClosed,
+
+    position: undefined as Position | undefined,
   };
 }

--- a/src/stories/molecule/PositionItemV2/hooks.tsx
+++ b/src/stories/molecule/PositionItemV2/hooks.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { parseUnits } from 'viem';
 
 import { useClaimPosition } from '~/hooks/useClaimPosition';
-import { useClosePosition } from '~/hooks/useClosePosition';
 import { useEntireMarkets } from '~/hooks/useMarket';
 import { usePositions } from '~/hooks/usePositions';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
@@ -143,13 +142,8 @@ export function usePositionItemV2({ position }: UsePositionItemV2) {
   const key = position.id.toString();
 
   const direction = position.qty > 0n ? 'Long' : 'Short';
-
-  const { onClosePosition } = useClosePosition({
-    positionId: position.id,
-    marketAddress: position.marketAddress,
-  });
-  const { onClaimPosition } = useClaimPosition({
-    positionId: position.id,
+  const { onClaimPosition, isMutating: isClaimMutating } = useClaimPosition({
+    position,
     market: markets?.find((market) => market.address === position.marketAddress),
   });
 
@@ -169,10 +163,6 @@ export function usePositionItemV2({ position }: UsePositionItemV2) {
     key,
 
     direction,
-
-    onClosePosition,
-    onClaimPosition,
-
     isLoading,
 
     isOpening,
@@ -183,5 +173,9 @@ export function usePositionItemV2({ position }: UsePositionItemV2) {
     tpPriceClass,
     slPriceClass,
     pnlClass,
+    position,
+
+    onClaimPosition,
+    isClaimMutating,
   };
 }

--- a/src/stories/molecule/PositionItemV2/index.tsx
+++ b/src/stories/molecule/PositionItemV2/index.tsx
@@ -6,6 +6,9 @@ import { TooltipGuide } from '~/stories/atom/TooltipGuide';
 
 import { Position } from '~/typings/position';
 
+import { Suspense, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ClosePositonModal } from '~/stories/template/ClosePositionModal';
 import { usePositionItemV2 } from './hooks';
 
 export interface PositionItemV2Props {
@@ -32,8 +35,8 @@ export function PositionItemV2(props: PositionItemV2Props) {
 
     direction,
 
-    onClosePosition,
     onClaimPosition,
+    isClaimMutating,
 
     isLoading,
 
@@ -44,148 +47,179 @@ export function PositionItemV2(props: PositionItemV2Props) {
     tpPriceClass,
     slPriceClass,
     pnlClass,
+
+    position,
   } = usePositionItemV2(props);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <div className="text-left tr">
-      <div className="td td-first">
-        <div>
-          <div className="text-sm text-primary-light">
-            <SkeletonElement isLoading={isLoading} width={40}>
-              {entryTime}
-            </SkeletonElement>
-          </div>
-          <div className="flex items-center gap-2 mt-1">
-            <div className="flex items-center gap-1">
-              <SkeletonElement isLoading={isLoading} width={40}>
-                <h5>{tokenName}</h5>
-              </SkeletonElement>
-            </div>
-            <div className="flex items-center gap-1 pl-2 border-l">
-              <SkeletonElement isLoading={isLoading} width={40}>
-                <h5>{marketDescription}</h5>
-              </SkeletonElement>
-            </div>
-            <SkeletonElement isLoading={isLoading} width={40}>
-              <Tag label={direction} />
-            </SkeletonElement>
-          </div>
-        </div>
-      </div>
-      {isOpening && (
-        <div className="td">
-          <div className="flex items-center text-sm text-primary gap-[6px]">
-            <Loading size="sm" />
-            <p>Waiting for the next oracle round</p>
-            <TooltipGuide iconOnly label="opening-in-progress" />
-          </div>
-        </div>
-      )}
-      {isClosing && (
-        <div className="td">
-          <div className="flex items-center text-sm text-primary gap-[6px]">
-            <Loading size="sm" />
-            <p>Closing in progress</p>
-            <TooltipGuide iconOnly label="closing-in-progress" />
-          </div>
-        </div>
-      )}
-      {isOpened && (
-        <>
-          <div className="td">
-            <SkeletonElement isLoading={isLoading} width={40}>
-              {entryPrice}
-            </SkeletonElement>
-          </div>
-          <div className="td">
-            {/* Contract Qty */}
-            <SkeletonElement isLoading={isLoading} width={40}>
-              {qty}
-            </SkeletonElement>
-          </div>
-          <div className="td w-[6px] border-r pr-4">
-            {/* Leverage */}
-            <SkeletonElement isLoading={isLoading} width={40}>
-              <Tag label={leverage} className="tag-leverage" />
-            </SkeletonElement>
-          </div>
-          <div className="td w-[6px]">
-            {/* TP */}
-            <div>
-              <SkeletonElement isLoading={isLoading} width={40}>
-                {profitPrice}
-              </SkeletonElement>
-              <div className={`mt-[2px] ${tpPriceClass}`}>
-                <SkeletonElement isLoading={isLoading} width={40}>
-                  {profitPriceTo}
-                </SkeletonElement>
-              </div>
-            </div>
-          </div>
-          <div className="td w-[6px]">
-            {/* SL */}
-            <div>
-              <SkeletonElement isLoading={isLoading} width={40}>
-                {lossPrice}
-              </SkeletonElement>
-              <div className={`mt-[2px] ${slPriceClass}`}>
-                <SkeletonElement isLoading={isLoading} width={40}>
-                  {lossPriceTo}
-                </SkeletonElement>
-              </div>
-            </div>
-          </div>
-          <div className="td td-pnl">
-            {/* PnL */}
-            <div>
-              <SkeletonElement isLoading={isLoading} width={40}>
-                {pnlAmount}
-              </SkeletonElement>
-              <div className={`mt-[2px] ${pnlClass}`}>
-                <SkeletonElement isLoading={isLoading} width={40}>
-                  {pnlPercentage}
-                </SkeletonElement>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-      {isClosed && (
-        <>
-          <div className="pr-4 border-r td">
-            <div className="flex text-sm text-primary">
-              The position has been closed(or liquidated). Please claim the cETH to your account.
-            </div>
-          </div>
-          <div className="td td-pnl">
-            {/* PnL */}
-            <div>
-              <SkeletonElement isLoading={isLoading} width={40}>
-                {pnlAmount}
-              </SkeletonElement>
-              <div className={`mt-[2px] ${pnlClass}`}>
-                <SkeletonElement isLoading={isLoading} width={40}>
-                  {pnlPercentage}
-                </SkeletonElement>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-
-      <div className="td td-last">
-        <div>
+    <>
+      <div className="text-left tr">
+        <div className="td td-first">
           <div>
-            {(isOpened || isOpening) && (
-              <Button label="Close" css="underlined" size="sm" onClick={onClosePosition} />
-            )}
-            {isClosed && (
-              <Button label="Claim" css="underlined" size="sm" onClick={onClaimPosition} />
-            )}
-            {isClosing && <Button label="Claim" css="underlined" size="sm" disabled={true} />}
+            <div className="text-sm text-primary-light">
+              <SkeletonElement isLoading={isLoading} width={40}>
+                {entryTime}
+              </SkeletonElement>
+            </div>
+            <div className="flex items-center gap-2 mt-1">
+              <div className="flex items-center gap-1">
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  <h5>{tokenName}</h5>
+                </SkeletonElement>
+              </div>
+              <div className="flex items-center gap-1 pl-2 border-l">
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  <h5>{marketDescription}</h5>
+                </SkeletonElement>
+              </div>
+              <SkeletonElement isLoading={isLoading} width={40}>
+                <Tag label={direction} />
+              </SkeletonElement>
+            </div>
+          </div>
+        </div>
+        {isOpening && (
+          <div className="td">
+            <div className="flex items-center text-sm text-primary gap-[6px]">
+              <Loading size="sm" />
+              <p>Waiting for the next oracle round</p>
+              <TooltipGuide iconOnly label="opening-in-progress" />
+            </div>
+          </div>
+        )}
+        {isClosing && (
+          <div className="td">
+            <div className="flex items-center text-sm text-primary gap-[6px]">
+              <Loading size="sm" />
+              <p>Closing in progress</p>
+              <TooltipGuide iconOnly label="closing-in-progress" />
+            </div>
+          </div>
+        )}
+        {isOpened && (
+          <>
+            <div className="td">
+              <SkeletonElement isLoading={isLoading} width={40}>
+                {entryPrice}
+              </SkeletonElement>
+            </div>
+            <div className="td">
+              {/* Contract Qty */}
+              <SkeletonElement isLoading={isLoading} width={40}>
+                {qty}
+              </SkeletonElement>
+            </div>
+            <div className="td w-[6px] border-r pr-4">
+              {/* Leverage */}
+              <SkeletonElement isLoading={isLoading} width={40}>
+                <Tag label={leverage} className="tag-leverage" />
+              </SkeletonElement>
+            </div>
+            <div className="td w-[6px]">
+              {/* TP */}
+              <div>
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  {profitPrice}
+                </SkeletonElement>
+                <div className={`mt-[2px] ${tpPriceClass}`}>
+                  <SkeletonElement isLoading={isLoading} width={40}>
+                    {profitPriceTo}
+                  </SkeletonElement>
+                </div>
+              </div>
+            </div>
+            <div className="td w-[6px]">
+              {/* SL */}
+              <div>
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  {lossPrice}
+                </SkeletonElement>
+                <div className={`mt-[2px] ${slPriceClass}`}>
+                  <SkeletonElement isLoading={isLoading} width={40}>
+                    {lossPriceTo}
+                  </SkeletonElement>
+                </div>
+              </div>
+            </div>
+            <div className="td td-pnl">
+              {/* PnL */}
+              <div>
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  {pnlAmount}
+                </SkeletonElement>
+                <div className={`mt-[2px] ${pnlClass}`}>
+                  <SkeletonElement isLoading={isLoading} width={40}>
+                    {pnlPercentage}
+                  </SkeletonElement>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+        {isClosed && (
+          <>
+            <div className="pr-4 border-r td">
+              <div className="flex text-sm text-primary">
+                The position has been closed(or liquidated). Please claim the cETH to your account.
+              </div>
+            </div>
+            <div className="td td-pnl">
+              {/* PnL */}
+              <div>
+                <SkeletonElement isLoading={isLoading} width={40}>
+                  {pnlAmount}
+                </SkeletonElement>
+                <div className={`mt-[2px] ${pnlClass}`}>
+                  <SkeletonElement isLoading={isLoading} width={40}>
+                    {pnlPercentage}
+                  </SkeletonElement>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        <div className="td td-last">
+          <div>
+            <div>
+              {(isOpened || isOpening) && (
+                <Button
+                  label="Close"
+                  css="underlined"
+                  size="sm"
+                  onClick={() => {
+                    setIsModalOpen(true);
+                  }}
+                />
+              )}
+              {isClosed && (
+                <Button
+                  label="Claim"
+                  css="underlined"
+                  size="sm"
+                  onClick={() => {
+                    onClaimPosition?.();
+                  }}
+                  disabled={isClaimMutating}
+                />
+              )}
+              {isClosing && <Button label="Claim" css="underlined" size="sm" disabled={true} />}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      <Suspense>
+        {isModalOpen &&
+          createPortal(
+            <ClosePositonModal
+              isOpen={isModalOpen}
+              onClose={() => setIsModalOpen(false)}
+              position={position}
+            />,
+            document.getElementById('modal')!
+          )}
+      </Suspense>
+    </>
   );
 }

--- a/src/stories/template/AirdropZealyConnectModal/index.tsx
+++ b/src/stories/template/AirdropZealyConnectModal/index.tsx
@@ -23,7 +23,7 @@ export function AirdropZealyConnectModal(props: AirdropZealyConnectModalProps) {
           <Dialog.Title className="modal-title">
             <ModalCloseButton onClick={onClose} />
           </Dialog.Title>
-          <Dialog.Description className="gap-5 modal-content">
+          <Dialog.Description className="gap-5 modal-content" as="div">
             <article className="text-center">
               <h4 className="text-2xl">Please connect your wallet to Zealy account.</h4>
               <p className="mt-3 mb-6 text-primary-light">

--- a/src/stories/template/AirdropZealyConvertModal/index.tsx
+++ b/src/stories/template/AirdropZealyConvertModal/index.tsx
@@ -31,7 +31,7 @@ export function AirdropZealyConvertModal(props: AirdropZealyConvertModalProps) {
           <Dialog.Title className="modal-title">
             <ModalCloseButton onClick={onClose} />
           </Dialog.Title>
-          <Dialog.Description className="gap-5 modal-content">
+          <Dialog.Description className="gap-5 modal-content" as="div">
             <article className="text-center">
               {title && <h2 className="mb-3 text-4xl">{title}</h2>}
               <p className="mb-6 whitespace-pre-line text-primary-light">{content}</p>

--- a/src/stories/template/ClosePositionModal/__mocks__/hooks.tsx
+++ b/src/stories/template/ClosePositionModal/__mocks__/hooks.tsx
@@ -1,13 +1,25 @@
+import { useState } from 'react';
+
 export function useClosePositonModal() {
+  const [isOpen, setIsOpen] = useState(true);
   return {
-    isOpen: true,
-    onClose: () => {},
+    isOpen,
+    onClose: () => {
+      setIsOpen(false);
+    },
 
-    tokenName: 'CHRM',
-
-    onClickAll: () => {},
-    onClickRemovable: () => {},
-
-    onClickSubmit: () => {},
+    position: {
+      qty: '15,000.00 cETH',
+      collateral: '1,500.00 cETH',
+      leverage: '10.00x',
+      direction: 'long',
+      tokenName: 'cETH',
+      marketDescription: 'ETH/USD',
+      marketImage: '',
+      entryPrice: '$ 2,200.00',
+      pnl: '+2.00 cETH',
+      pnlPercentage: '+20.00%',
+      pnlClass: 'text-price-higher',
+    },
   };
 }

--- a/src/stories/template/ClosePositionModal/hooks.tsx
+++ b/src/stories/template/ClosePositionModal/hooks.tsx
@@ -41,6 +41,7 @@ export function useClosePositonModal(props: ClosePositionModalProps) {
       collateral: `${formatDecimals(collateral, token.decimals, 2, true)} ${token.name}`,
       direction: qty > 0n ? 'long' : 'short',
       tokenName: token.name,
+      tokenImage: token.image,
       marketDescription: market.description,
       marketImage: market.image,
       entryPrice,

--- a/src/stories/template/ClosePositionModal/hooks.tsx
+++ b/src/stories/template/ClosePositionModal/hooks.tsx
@@ -1,15 +1,66 @@
-import { usePoolRemoveInput } from '~/hooks/usePoolRemoveInput';
+import { isNil, isNotNil } from 'ramda';
+import { useCallback, useMemo } from 'react';
+import { ORACLE_PROVIDER_DECIMALS, PERCENT_DECIMALS, PNL_RATE_DECIMALS } from '~/configs/decimals';
+import useFilteredMarkets from '~/hooks/commons/useFilteredMarkets';
+import { useClosePosition } from '~/hooks/useClosePosition';
 import { useSettlementToken } from '~/hooks/useSettlementToken';
+import { abs, divPreserved, formatDecimals } from '~/utils/number';
+import { ClosePositionModalProps } from '.';
 
-export function useClosePositonModal() {
-  const { onAmountChange } = usePoolRemoveInput();
-  const { currentToken } = useSettlementToken();
+export function useClosePositonModal(props: ClosePositionModalProps) {
+  const { isOpen, onClose, position } = props;
+  const { tokens } = useSettlementToken();
+  const { markets } = useFilteredMarkets();
+  const { onClosePosition, isMutating } = useClosePosition({
+    positionId: position?.id,
+    marketAddress: position?.marketAddress,
+  });
 
-  const onClose = () => {
-    onAmountChange();
-  };
+  const formattedPosition = useMemo(() => {
+    if (isNil(position) || isNil(tokens) || isNil(markets)) {
+      return;
+    }
+    const { tokenAddress, marketAddress, qty, openPrice, collateral, takerMargin, pnl } = position;
+    const token = tokens.find((token) => token.address === tokenAddress);
+    const market = markets.find((market) => market.address === marketAddress);
+    if (isNil(token) || isNil(market)) {
+      return;
+    }
+
+    const entryPrice = `$ ${formatDecimals(openPrice, ORACLE_PROVIDER_DECIMALS, 2, true)}`;
+    const leverage = `${formatDecimals(
+      divPreserved(abs(qty), collateral, token.decimals),
+      token.decimals,
+      2,
+      true
+    )}x`;
+    const pnlPercentage = divPreserved(pnl, takerMargin, PNL_RATE_DECIMALS + PERCENT_DECIMALS);
+    const plusSign = pnl > 0n ? '+' : '';
+    return {
+      qty: `${formatDecimals(abs(qty), token.decimals, 2, true)} ${token.name}`,
+      collateral: `${formatDecimals(collateral, token.decimals, 2, true)} ${token.name}`,
+      direction: qty > 0n ? 'long' : 'short',
+      tokenName: token.name,
+      marketDescription: market.description,
+      marketImage: market.image,
+      entryPrice,
+      leverage,
+      pnl: `${plusSign}${formatDecimals(pnl, token.decimals, 2, true)} ${token.name}`,
+      pnlPercentage: `${plusSign}${formatDecimals(pnlPercentage, PNL_RATE_DECIMALS, 2, true)}%`,
+      pnlClass: pnl > 0n ? 'text-price-higher' : 'text-price-lower',
+    };
+  }, [position, tokens, markets]);
+
+  const onPositionClose = useCallback(async () => {
+    await onClosePosition?.();
+    onClose?.();
+  }, [onClosePosition, onClose]);
 
   return {
+    isOpen: (isOpen && isNotNil(position)) ?? false,
+    isMutating,
+    position: formattedPosition,
     onClose,
+    onPositionClose,
   };
 }

--- a/src/stories/template/ClosePositionModal/index.tsx
+++ b/src/stories/template/ClosePositionModal/index.tsx
@@ -29,15 +29,23 @@ export function ClosePositonModal(props: ClosePositionModalProps) {
           </Dialog.Title>
           {/* <div className="w-[100px] mx-auto border-b border-2 !border-primary"></div> */}
           <Dialog.Description className="gap-5 modal-content" as="div">
-            <article className="px-4 pt-3 pb-4 modal-box">
-              <div className="flex items-center gap-3 pb-3 mb-4 border-b">
-                <Avatar size="2xl" src={position?.marketImage} />
-                <div className="flex items-center gap-2 mt-1">
-                  <h5>{position?.tokenName}</h5>
-                  <h5 className="pl-2 border-l border-primary-light">
-                    {position?.marketDescription}
-                  </h5>
-                  {/* <Tag label={direction} /> */}
+            <article className="px-4 pt-4 pb-4 modal-box">
+              <div className="flex items-center gap-3 pb-4 mb-4 border-b">
+                <div className="flex items-center gap-2">
+                  <Avatar
+                    size="sm"
+                    fontSize="lg"
+                    gap="1"
+                    src={position?.tokenImage}
+                    label={position?.tokenName}
+                  />
+                  <Avatar
+                    size="sm"
+                    fontSize="lg"
+                    gap="1"
+                    src={position?.marketImage}
+                    label={position?.marketDescription}
+                  />
                   <Tag label={position?.direction} />
                 </div>
               </div>

--- a/src/stories/template/ClosePositionModal/index.tsx
+++ b/src/stories/template/ClosePositionModal/index.tsx
@@ -1,24 +1,25 @@
 import '~/stories/template/Modal/style.css';
 
-import { useState } from 'react';
 import { Dialog } from '@headlessui/react';
 import { Avatar } from '~/stories/atom/Avatar';
 import { Button } from '~/stories/atom/Button';
-import { Tag } from '~/stories/atom/Tag';
 import { ModalCloseButton } from '~/stories/atom/ModalCloseButton';
+import { Tag } from '~/stories/atom/Tag';
+import { Position } from '~/typings/position';
 import { useClosePositonModal } from './hooks';
 
-export function ClosePositonModal() {
-  const {
-    onClose,
-    // tokenName,
-    // marketDescription,
-    // direction,
-  } = useClosePositonModal();
-  let [isOpen, setIsOpen] = useState(true);
+export interface ClosePositionModalProps {
+  isOpen?: boolean;
+  onClose?: () => unknown;
+
+  position?: Position;
+}
+
+export function ClosePositonModal(props: ClosePositionModalProps) {
+  const { isOpen, isMutating, onClose, position, onPositionClose } = useClosePositonModal(props);
 
   return (
-    <Dialog open={isOpen} onClose={onClose}>
+    <Dialog open={isOpen} onClose={() => onClose?.()}>
       <div className="backdrop" aria-hidden="true" />
       <div className="fixed inset-0 z-40 flex items-center justify-center p-4 shadow-xl">
         <Dialog.Panel className="modal modal-base">
@@ -27,41 +28,37 @@ export function ClosePositonModal() {
             <ModalCloseButton onClick={onClose} />
           </Dialog.Title>
           {/* <div className="w-[100px] mx-auto border-b border-2 !border-primary"></div> */}
-          <Dialog.Description className="gap-5 modal-content">
+          <Dialog.Description className="gap-5 modal-content" as="div">
             <article className="px-4 pt-3 pb-4 modal-box">
               <div className="flex items-center gap-3 pb-3 mb-4 border-b">
-                <Avatar size="2xl" />
+                <Avatar size="2xl" src={position?.marketImage} />
                 <div className="flex items-center gap-2 mt-1">
-                  <h5>
-                    {/* {tokenName} */}
-                    CHRM
-                  </h5>
+                  <h5>{position?.tokenName}</h5>
                   <h5 className="pl-2 border-l border-primary-light">
-                    {/* {marketDescription} */}
-                    ETH/USD
+                    {position?.marketDescription}
                   </h5>
                   {/* <Tag label={direction} /> */}
-                  <Tag label="long" />
+                  <Tag label={position?.direction} />
                 </div>
               </div>
               <div className="flex gap-5 mb-3">
                 <div className="w-1/2">
                   <p className="mb-1 text-primary-light">Entry Price</p>
-                  <p>$27,625.42</p>
+                  <p>{position?.entryPrice}</p>
                 </div>
                 <div className="w-1/2">
                   <p className="mb-1 text-primary-light">Leverage</p>
-                  <Tag label="10.00x" className="tag-leverage" />
+                  <Tag label={position?.leverage} className="tag-leverage" />
                 </div>
               </div>
               <div className="flex gap-5">
                 <div className="w-1/2">
                   <p className="mb-1 text-primary-light">Contract qty</p>
-                  <p>1,500.00 cETH</p>
+                  <p>{position?.qty}</p>
                 </div>
                 <div className="w-1/2">
                   <p className="mb-1 text-primary-light">Collateral</p>
-                  <p>1,500.00 cETH</p>
+                  <p>{position?.collateral}</p>
                 </div>
               </div>
             </article>
@@ -69,9 +66,9 @@ export function ClosePositonModal() {
             <article className="flex flex-col">
               <div className="flex items-center justify-between">
                 <div className="flex text-primary-light">Estimated PnL</div>
-                <div className="flex items-baseline gap-1 text-price-higher">
-                  <h4 className="text-xl">+34.12 cETH</h4>
-                  <p>(+12.78%)</p>
+                <div className={'flex items-baseline gap-1 ' + position?.pnlClass}>
+                  <h4 className="text-xl">{position?.pnl}</h4>
+                  <p>({position?.pnlPercentage})</p>
                 </div>
                 {/* <div className="flex items-baseline gap-1 text-price-lower">
                   <h4 className="text-xl">-34.12 cETH</h4>
@@ -79,8 +76,9 @@ export function ClosePositonModal() {
                 </div> */}
               </div>
               <p className="pt-3 mt-3 border-t text-primary-light">
-                You will close 15,000.00 cETH-cETH/USD position with and estimated profit of{' '}
-                <span className="text-price-higher">+34.12 cETH</span>.
+                You will close {position?.qty} {position?.tokenName}-{position?.marketDescription}{' '}
+                position with and estimated profit of{' '}
+                <span className={position?.pnlClass}>{position?.pnl}</span>.
               </p>
             </article>
           </Dialog.Description>
@@ -90,7 +88,8 @@ export function ClosePositonModal() {
               size="xl"
               className="text-lg"
               css="active"
-              // onClick={}
+              onClick={() => onPositionClose()}
+              disabled={isMutating}
             />
           </div>
         </Dialog.Panel>

--- a/src/stories/template/ClosePositionModal/index.tsx
+++ b/src/stories/template/ClosePositionModal/index.tsx
@@ -29,18 +29,18 @@ export function ClosePositonModal(props: ClosePositionModalProps) {
           </Dialog.Title>
           {/* <div className="w-[100px] mx-auto border-b border-2 !border-primary"></div> */}
           <Dialog.Description className="gap-5 modal-content" as="div">
-            <article className="px-4 pt-4 pb-4 modal-box">
-              <div className="flex items-center gap-3 pb-4 mb-4 border-b">
-                <div className="flex items-center gap-2">
+            <article className="px-4 pt-6 pb-4 modal-box">
+              <div className="flex items-center gap-3 pb-6 mb-4 border-b">
+                <div className="flex items-center gap-3">
                   <Avatar
-                    size="sm"
+                    size="base"
                     fontSize="lg"
                     gap="1"
                     src={position?.tokenImage}
                     label={position?.tokenName}
                   />
                   <Avatar
-                    size="sm"
+                    size="base"
                     fontSize="lg"
                     gap="1"
                     src={position?.marketImage}


### PR DESCRIPTION
## Description

- Show modal to close positions
  - When clicking `close` button on each positions
  - Format positions to show data on modal
  - Hooks to show mock data on Storybook

- Use `useSWRMutation`
  - Disable buttons when closing or claiming positions
  - `close` buttons on `ClosePositionModal`
  - `claim` buttons on `PositionItem`

- Component warning from `validateDOMNesting`

## Related Issues

fixes #678 

